### PR TITLE
Exception when fetching an issue with one and only one linked issue

### DIFF
--- a/src/YouTrackSharp/Issues/IssueTypeConverter.cs
+++ b/src/YouTrackSharp/Issues/IssueTypeConverter.cs
@@ -86,14 +86,32 @@ namespace YouTrackSharp.Issues
         IList<Link> ConvertLinks(dynamic values)
         {
             var links = new List<Link>();
-            for (int i = 0; i < values.Length; i++)
+
+            if (values.GetType() == typeof(ExpandoObject[]))
             {
-                var value = (IDictionary<string,object>)values[i];
-                // THe reason for the casting is because there's a field called $ that you cannot access otherwise.
-                var link = new Link() {Type = value["type"].ToString(), Role = value["role"].ToString(), Value = value["$"].ToString()};
+              for (int i = 0; i < values.Length; i++)
+              {
+                var link = ConvertLink(values[i]);
                 links.Add(link);
+              }
             }
-            return links;
+            else
+              links.Add(ConvertLink(values));
+
+          return links;
         }
+
+      private static Link ConvertLink(dynamic val)
+      {
+        var value = (IDictionary<string, object>) val;
+        // THe reason for the casting is because there's a field called $ that you cannot access otherwise.
+        var link = new Link()
+                     {
+                       Type = value["type"].ToString(),
+                       Role = value["role"].ToString(),
+                       Value = value["$"].ToString()
+                     };
+        return link;
+      }
     }
 }


### PR DESCRIPTION
If the issue contains only one linked issue the json returned does not contain an array of links but only a single item. This fix checks for this and treats it as a single expandoobject if true.
