### PR TITLE
Allow authentication via NetworkCredentials

### DIFF
--- a/src/YouTrackSharp.Specs/Specs/ConnectionSpecs.cs
+++ b/src/YouTrackSharp.Specs/Specs/ConnectionSpecs.cs
@@ -30,6 +30,8 @@
 #endregion
 
 using System;
+using System.Net;
+using System.Security;
 using System.Security.Authentication;
 using Machine.Specifications;
 using YouTrackSharp.Admin;
@@ -46,6 +48,28 @@ namespace YouTrackSharp.Specs.Specs
 
         It should_succeed = () => connection.IsAuthenticated.ShouldBeTrue();
 
+    }
+
+    [Subject(typeof(Connection))]
+    public class when_authenticating_with_valid_netword_credentials_given_valid_connection_details : YouTrackConnection
+    {
+        Because of = () => connection.Authenticate(new NetworkCredential("youtrackapi", "youtrackapi"));
+
+        It should_succeed = () => connection.IsAuthenticated.ShouldBeTrue();
+    }
+
+    [Subject(typeof(Connection))]
+    public class when_authenticating_with_valid_username_and_secure_string_given_valid_connection_details : YouTrackConnection
+    {
+        Because of = () =>
+        {
+            var secure = new SecureString();
+            foreach (var c in "youtrackapi")
+                secure.AppendChar(c);
+            connection.Authenticate(new NetworkCredential("youtrackapi", secure));
+        };
+
+        It should_succeed = () => connection.IsAuthenticated.ShouldBeTrue();
     }
 
     [Subject(typeof (Connection))]

--- a/src/YouTrackSharp/Infrastructure/Connection.cs
+++ b/src/YouTrackSharp/Infrastructure/Connection.cs
@@ -166,6 +166,11 @@ namespace YouTrackSharp.Infrastructure
             return httpRequest.Response.DynamicBody;
         }
 
+        public void Authenticate(NetworkCredential credentials)
+        {
+            Authenticate(credentials.UserName, credentials.Password);
+        }
+
         public void Authenticate(string username, string password)
         {
             IsAuthenticated = false;


### PR DESCRIPTION
Added method, and tests, to authenticate using
System.Net.NetworkCredentials. Has the added bonus of allowing users to 
authenticate with a SecureString from a password box.
