### PR TITLE
Fix retrieving more than 10 users in all

### DIFF
--- a/src/YouTrackSharp/Admin/UserManagement.cs
+++ b/src/YouTrackSharp/Admin/UserManagement.cs
@@ -34,6 +34,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using YouTrackSharp.Infrastructure;
 
 namespace YouTrackSharp.Admin
@@ -49,15 +50,24 @@ namespace YouTrackSharp.Admin
 
 		public IEnumerable<User> GetAllUsers()
 		{
-			ICollection<User> users = new Collection<User>();
-			IEnumerable<AllUsersItem> userItems = _connection.Get<IEnumerable<AllUsersItem>>("admin/user");
+            ICollection<User> users = new Collection<User>();
+            int position = 0;
+            IEnumerable<AllUsersItem> userItems = null;
 
-			foreach (AllUsersItem userItem in userItems)
-			{
-				users.Add(GetUserByUserName(userItem.Login));
-			}
+            do
+            {
+                userItems = _connection.Get<IEnumerable<AllUsersItem>>(String.Format("admin/user/?start={0}", position));
 
-			return users;
+                foreach (AllUsersItem userItem in userItems)
+                {
+                    users.Add(GetUserByUserName(userItem.Login));
+                }
+
+                position += 10;
+            }
+            while (userItems != null && userItems.Any());
+
+            return users;
 		}
 
 		public User GetUserByUserName(string username)

--- a/src/YouTrackSharp/Admin/UserManagement.cs
+++ b/src/YouTrackSharp/Admin/UserManagement.cs
@@ -50,24 +50,24 @@ namespace YouTrackSharp.Admin
 
 		public IEnumerable<User> GetAllUsers()
 		{
-            ICollection<User> users = new Collection<User>();
-            int position = 0;
-            IEnumerable<AllUsersItem> userItems = null;
+			ICollection<User> users = new Collection<User>();
+			int position = 0;
+			IEnumerable<AllUsersItem> userItems = null;
 
-            do
-            {
-                userItems = _connection.Get<IEnumerable<AllUsersItem>>(String.Format("admin/user/?start={0}", position));
+			do
+			{
+				userItems = _connection.Get<IEnumerable<AllUsersItem>>(String.Format("admin/user/?start={0}", position));
 
-                foreach (AllUsersItem userItem in userItems)
-                {
-                    users.Add(GetUserByUserName(userItem.Login));
-                }
+				foreach (AllUsersItem userItem in userItems)
+				{
+					users.Add(GetUserByUserName(userItem.Login));
+				}
 
-                position += 10;
-            }
-            while (userItems != null && userItems.Any());
+				position += 10;
+			}
+			while (userItems != null && userItems.Any());
 
-            return users;
+			return users;
 		}
 
 		public User GetUserByUserName(string username)


### PR DESCRIPTION
Retrieving all users only ever returns the first 10. Looking closer at the API documentation, it seems that the pagination is implied. This PR implements pagination so that all users are retrieved.

Tested with YouTrack 6.0 (build 12577).
