### PR TITLE
Agile

### DIFF
--- a/src/YouTrackSharp/Agiles/Agile.cs
+++ b/src/YouTrackSharp/Agiles/Agile.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using YouTrackSharp.Json;
 using YouTrackSharp.Management;
 using YouTrackSharp.Projects;
 
@@ -103,6 +104,7 @@ namespace YouTrackSharp.Agiles {
     /// Settings of the board swimlanes. Can be null.
     /// </summary>
     [JsonProperty("swimlaneSettings")]
+    [JsonConverter(typeof(KnownTypeConverter<SwimlaneSettings>))]
     public SwimlaneSettings SwimlaneSettings { get; set; }
 
     /// <summary>
@@ -115,6 +117,7 @@ namespace YouTrackSharp.Agiles {
     /// Color coding settings for the board. Can be null.
     /// </summary>
     [JsonProperty("colorCoding")]
+    [JsonConverter(typeof(KnownTypeConverter<ColorCoding>))]
     public ColorCoding ColorCoding { get; set; }
 
     /// <summary>

--- a/src/YouTrackSharp/Agiles/Agile.cs
+++ b/src/YouTrackSharp/Agiles/Agile.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using YouTrackSharp.Json;
 using YouTrackSharp.Management;
 using YouTrackSharp.Projects;
+using YouTrackSharp.SerializationAttributes;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
@@ -30,24 +31,28 @@ namespace YouTrackSharp.Agiles {
     /// <summary>
     /// The user group that can view this board. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("visibleFor")]
     public Group VisibleFor { get; set; }
 
     /// <summary>
     /// When true, the board is visible to everyone who can view all projects that are associated with the board.
     /// </summary>
+    [Verbose]
     [JsonProperty("visibleForProjectBased")]
     public bool VisibleForProjectBased { get; set; }
 
     /// <summary>
     /// Group of users who can update board settings. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("updateableBy")]
     public Group UpdateableBy { get; set; }
 
     /// <summary>
     /// When true, anyone who can update the associated projects can update the board.
     /// </summary>
+    [Verbose]
     [JsonProperty("updateableByProjectBased")]
     public bool UpdateableByProjectBased { get; set; }
 
@@ -55,54 +60,63 @@ namespace YouTrackSharp.Agiles {
     /// When true, the orphan swimlane is placed at the top of the board. Otherwise, the orphans swimlane is located
     /// below all other swimlanes.
     /// </summary>
+    [Verbose]
     [JsonProperty("orphansAtTheTop")]
     public bool OrphansAtTheTop { get; set; }
 
     /// <summary>
     /// When true, the orphans swimlane is not displayed on the board.
     /// </summary>
+    [Verbose]
     [JsonProperty("hideOrphansSwimlane")]
     public bool HideOrphansSwimlane { get; set; }
 
     /// <summary>
     /// A custom field that is used as the estimation field for the board. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("estimationField")]
     public CustomField EstimationField { get; set; }
 
     /// <summary>
     /// A custom field that is used as the original estimation field for the board. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("originalEstimationField")]
     public CustomField OriginalEstimationField { get; set; }
 
     /// <summary>
     /// A collection of projects associated with the board.
     /// </summary>
+    [Verbose]
     [JsonProperty("projects")]
     public List<Project> Projects { get; set; }
 
     /// <summary>
     /// The set of sprints that are associated with the board.
     /// </summary>
+    [Verbose]
     [JsonProperty("sprints")]
     public List<Sprint> Sprints { get; set; }
 
     /// <summary>
     /// A sprint that is actual for the current date. Read-only. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("currentSprint")]
     public Sprint CurrentSprint { get; set; }
 
     /// <summary>
     /// Column settings of the board. Read-only.
     /// </summary>
+    [Verbose]
     [JsonProperty("columnSettings")]
     public ColumnSettings ColumnSettings { get; set; }
 
     /// <summary>
     /// Settings of the board swimlanes. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("swimlaneSettings")]
     [JsonConverter(typeof(KnownTypeConverter<SwimlaneSettings>))]
     public SwimlaneSettings SwimlaneSettings { get; set; }
@@ -110,12 +124,14 @@ namespace YouTrackSharp.Agiles {
     /// <summary>
     /// Settings of the board sprints. Read-only.
     /// </summary>
+    [Verbose]
     [JsonProperty("sprintsSettings")]
     public SprintsSettings SprintsSettings { get; set; }
 
     /// <summary>
     /// Color coding settings for the board. Can be null.
     /// </summary>
+    [Verbose]
     [JsonProperty("colorCoding")]
     [JsonConverter(typeof(KnownTypeConverter<ColorCoding>))]
     public ColorCoding ColorCoding { get; set; }
@@ -123,6 +139,7 @@ namespace YouTrackSharp.Agiles {
     /// <summary>
     /// Status of the board. Read-only.
     /// </summary>
+    [Verbose]
     [JsonProperty("status")]
     public AgileStatus Status { get; set; }
   }

--- a/src/YouTrackSharp/Agiles/Agile.cs
+++ b/src/YouTrackSharp/Agiles/Agile.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using YouTrackSharp.Json;
-using YouTrackSharp.Management;
 using YouTrackSharp.Projects;
 using YouTrackSharp.SerializationAttributes;
 
@@ -33,12 +32,11 @@ namespace YouTrackSharp.Agiles {
     /// </summary>
     [Verbose]
     [JsonProperty("visibleFor")]
-    public Group VisibleFor { get; set; }
+    public UserGroup VisibleFor { get; set; }
 
     /// <summary>
     /// When true, the board is visible to everyone who can view all projects that are associated with the board.
     /// </summary>
-    [Verbose]
     [JsonProperty("visibleForProjectBased")]
     public bool VisibleForProjectBased { get; set; }
 
@@ -47,12 +45,11 @@ namespace YouTrackSharp.Agiles {
     /// </summary>
     [Verbose]
     [JsonProperty("updateableBy")]
-    public Group UpdateableBy { get; set; }
+    public UserGroup UpdateableBy { get; set; }
 
     /// <summary>
     /// When true, anyone who can update the associated projects can update the board.
     /// </summary>
-    [Verbose]
     [JsonProperty("updateableByProjectBased")]
     public bool UpdateableByProjectBased { get; set; }
 
@@ -60,14 +57,12 @@ namespace YouTrackSharp.Agiles {
     /// When true, the orphan swimlane is placed at the top of the board. Otherwise, the orphans swimlane is located
     /// below all other swimlanes.
     /// </summary>
-    [Verbose]
     [JsonProperty("orphansAtTheTop")]
     public bool OrphansAtTheTop { get; set; }
 
     /// <summary>
     /// When true, the orphans swimlane is not displayed on the board.
     /// </summary>
-    [Verbose]
     [JsonProperty("hideOrphansSwimlane")]
     public bool HideOrphansSwimlane { get; set; }
 

--- a/src/YouTrackSharp/Agiles/Agile.cs
+++ b/src/YouTrackSharp/Agiles/Agile.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using YouTrackSharp.Management;
+using YouTrackSharp.Projects;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents an agile board configuration.
+  /// </summary>
+  public class Agile {
+    /// <summary>
+    /// Id of the Agile.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// The name of the agile board. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Owner of the agile board. Can be null.
+    /// </summary>
+    [JsonProperty("owner")]
+    public User Owner { get; set; }
+
+    /// <summary>
+    /// The user group that can view this board. Can be null.
+    /// </summary>
+    [JsonProperty("visibleFor")]
+    public Group VisibleFor { get; set; }
+
+    /// <summary>
+    /// When true, the board is visible to everyone who can view all projects that are associated with the board.
+    /// </summary>
+    [JsonProperty("visibleForProjectBased")]
+    public bool VisibleForProjectBased { get; set; }
+
+    /// <summary>
+    /// Group of users who can update board settings. Can be null.
+    /// </summary>
+    [JsonProperty("updateableBy")]
+    public Group UpdateableBy { get; set; }
+
+    /// <summary>
+    /// When true, anyone who can update the associated projects can update the board.
+    /// </summary>
+    [JsonProperty("updateableByProjectBased")]
+    public bool UpdateableByProjectBased { get; set; }
+
+    /// <summary>
+    /// When true, the orphan swimlane is placed at the top of the board. Otherwise, the orphans swimlane is located
+    /// below all other swimlanes.
+    /// </summary>
+    [JsonProperty("orphansAtTheTop")]
+    public bool OrphansAtTheTop { get; set; }
+
+    /// <summary>
+    /// When true, the orphans swimlane is not displayed on the board.
+    /// </summary>
+    [JsonProperty("hideOrphansSwimlane")]
+    public bool HideOrphansSwimlane { get; set; }
+
+    /// <summary>
+    /// A custom field that is used as the estimation field for the board. Can be null.
+    /// </summary>
+    [JsonProperty("estimationField")]
+    public CustomField EstimationField { get; set; }
+
+    /// <summary>
+    /// A custom field that is used as the original estimation field for the board. Can be null.
+    /// </summary>
+    [JsonProperty("originalEstimationField")]
+    public CustomField OriginalEstimationField { get; set; }
+
+    /// <summary>
+    /// A collection of projects associated with the board.
+    /// </summary>
+    [JsonProperty("projects")]
+    public List<Project> Projects { get; set; }
+
+    /// <summary>
+    /// The set of sprints that are associated with the board.
+    /// </summary>
+    [JsonProperty("sprints")]
+    public List<Sprint> Sprints { get; set; }
+
+    /// <summary>
+    /// A sprint that is actual for the current date. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("currentSprint")]
+    public Sprint CurrentSprint { get; set; }
+
+    /// <summary>
+    /// Column settings of the board. Read-only.
+    /// </summary>
+    [JsonProperty("columnSettings")]
+    public ColumnSettings ColumnSettings { get; set; }
+
+    /// <summary>
+    /// Settings of the board swimlanes. Can be null.
+    /// </summary>
+    [JsonProperty("swimlaneSettings")]
+    public SwimlaneSettings SwimlaneSettings { get; set; }
+
+    /// <summary>
+    /// Settings of the board sprints. Read-only.
+    /// </summary>
+    [JsonProperty("sprintsSettings")]
+    public SprintsSettings SprintsSettings { get; set; }
+
+    /// <summary>
+    /// Color coding settings for the board. Can be null.
+    /// </summary>
+    [JsonProperty("colorCoding")]
+    public ColorCoding ColorCoding { get; set; }
+
+    /// <summary>
+    /// Status of the board. Read-only.
+    /// </summary>
+    [JsonProperty("status")]
+    public AgileStatus Status { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/Agile.cs
+++ b/src/YouTrackSharp/Agiles/Agile.cs
@@ -4,138 +4,140 @@ using YouTrackSharp.Json;
 using YouTrackSharp.Projects;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents an agile board configuration.
-  /// </summary>
-  public class Agile {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the Agile.
+    /// Represents an agile board configuration.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class Agile
+    {
+        /// <summary>
+        /// Id of the Agile.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// The name of the agile board. Can be null.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
+        /// <summary>
+        /// The name of the agile board. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-    /// <summary>
-    /// Owner of the agile board. Can be null.
-    /// </summary>
-    [JsonProperty("owner")]
-    public User Owner { get; set; }
+        /// <summary>
+        /// Owner of the agile board. Can be null.
+        /// </summary>
+        [JsonProperty("owner")]
+        public User Owner { get; set; }
 
-    /// <summary>
-    /// The user group that can view this board. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("visibleFor")]
-    public UserGroup VisibleFor { get; set; }
+        /// <summary>
+        /// The user group that can view this board. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("visibleFor")]
+        public UserGroup VisibleFor { get; set; }
 
-    /// <summary>
-    /// When true, the board is visible to everyone who can view all projects that are associated with the board.
-    /// </summary>
-    [JsonProperty("visibleForProjectBased")]
-    public bool VisibleForProjectBased { get; set; }
+        /// <summary>
+        /// When true, the board is visible to everyone who can view all projects that are associated with the board.
+        /// </summary>
+        [JsonProperty("visibleForProjectBased")]
+        public bool VisibleForProjectBased { get; set; }
 
-    /// <summary>
-    /// Group of users who can update board settings. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("updateableBy")]
-    public UserGroup UpdateableBy { get; set; }
+        /// <summary>
+        /// Group of users who can update board settings. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("updateableBy")]
+        public UserGroup UpdateableBy { get; set; }
 
-    /// <summary>
-    /// When true, anyone who can update the associated projects can update the board.
-    /// </summary>
-    [JsonProperty("updateableByProjectBased")]
-    public bool UpdateableByProjectBased { get; set; }
+        /// <summary>
+        /// When true, anyone who can update the associated projects can update the board.
+        /// </summary>
+        [JsonProperty("updateableByProjectBased")]
+        public bool UpdateableByProjectBased { get; set; }
 
-    /// <summary>
-    /// When true, the orphan swimlane is placed at the top of the board. Otherwise, the orphans swimlane is located
-    /// below all other swimlanes.
-    /// </summary>
-    [JsonProperty("orphansAtTheTop")]
-    public bool OrphansAtTheTop { get; set; }
+        /// <summary>
+        /// When true, the orphan swimlane is placed at the top of the board. Otherwise, the orphans swimlane is located
+        /// below all other swimlanes.
+        /// </summary>
+        [JsonProperty("orphansAtTheTop")]
+        public bool OrphansAtTheTop { get; set; }
 
-    /// <summary>
-    /// When true, the orphans swimlane is not displayed on the board.
-    /// </summary>
-    [JsonProperty("hideOrphansSwimlane")]
-    public bool HideOrphansSwimlane { get; set; }
+        /// <summary>
+        /// When true, the orphans swimlane is not displayed on the board.
+        /// </summary>
+        [JsonProperty("hideOrphansSwimlane")]
+        public bool HideOrphansSwimlane { get; set; }
 
-    /// <summary>
-    /// A custom field that is used as the estimation field for the board. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("estimationField")]
-    public CustomField EstimationField { get; set; }
+        /// <summary>
+        /// A custom field that is used as the estimation field for the board. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("estimationField")]
+        public CustomField EstimationField { get; set; }
 
-    /// <summary>
-    /// A custom field that is used as the original estimation field for the board. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("originalEstimationField")]
-    public CustomField OriginalEstimationField { get; set; }
+        /// <summary>
+        /// A custom field that is used as the original estimation field for the board. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("originalEstimationField")]
+        public CustomField OriginalEstimationField { get; set; }
 
-    /// <summary>
-    /// A collection of projects associated with the board.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("projects")]
-    public List<Project> Projects { get; set; }
+        /// <summary>
+        /// A collection of projects associated with the board.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("projects")]
+        public List<Project> Projects { get; set; }
 
-    /// <summary>
-    /// The set of sprints that are associated with the board.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("sprints")]
-    public List<Sprint> Sprints { get; set; }
+        /// <summary>
+        /// The set of sprints that are associated with the board.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("sprints")]
+        public List<Sprint> Sprints { get; set; }
 
-    /// <summary>
-    /// A sprint that is actual for the current date. Read-only. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("currentSprint")]
-    public Sprint CurrentSprint { get; set; }
+        /// <summary>
+        /// A sprint that is actual for the current date. Read-only. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("currentSprint")]
+        public Sprint CurrentSprint { get; set; }
 
-    /// <summary>
-    /// Column settings of the board. Read-only.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("columnSettings")]
-    public ColumnSettings ColumnSettings { get; set; }
+        /// <summary>
+        /// Column settings of the board. Read-only.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("columnSettings")]
+        public ColumnSettings ColumnSettings { get; set; }
 
-    /// <summary>
-    /// Settings of the board swimlanes. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("swimlaneSettings")]
-    [JsonConverter(typeof(KnownTypeConverter<SwimlaneSettings>))]
-    public SwimlaneSettings SwimlaneSettings { get; set; }
+        /// <summary>
+        /// Settings of the board swimlanes. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("swimlaneSettings")]
+        [JsonConverter(typeof(KnownTypeConverter<SwimlaneSettings>))]
+        public SwimlaneSettings SwimlaneSettings { get; set; }
 
-    /// <summary>
-    /// Settings of the board sprints. Read-only.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("sprintsSettings")]
-    public SprintsSettings SprintsSettings { get; set; }
+        /// <summary>
+        /// Settings of the board sprints. Read-only.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("sprintsSettings")]
+        public SprintsSettings SprintsSettings { get; set; }
 
-    /// <summary>
-    /// Color coding settings for the board. Can be null.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("colorCoding")]
-    [JsonConverter(typeof(KnownTypeConverter<ColorCoding>))]
-    public ColorCoding ColorCoding { get; set; }
+        /// <summary>
+        /// Color coding settings for the board. Can be null.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("colorCoding")]
+        [JsonConverter(typeof(KnownTypeConverter<ColorCoding>))]
+        public ColorCoding ColorCoding { get; set; }
 
-    /// <summary>
-    /// Status of the board. Read-only.
-    /// </summary>
-    [Verbose]
-    [JsonProperty("status")]
-    public AgileStatus Status { get; set; }
-  }
+        /// <summary>
+        /// Status of the board. Read-only.
+        /// </summary>
+        [Verbose]
+        [JsonProperty("status")]
+        public AgileStatus Status { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/AgileColumn.cs
+++ b/src/YouTrackSharp/Agiles/AgileColumn.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents settings for a single board column
+  /// </summary>
+  public class AgileColumn {
+    /// <summary>
+    /// Id of the AgileColumn.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Text presentation of values stored in a column. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("presentation")]
+    public string Presentation { get; set; }
+
+    /// <summary>
+    /// true if a column represents resolved state of an issue. Can be updated only for newly created value. Read-only.
+    /// </summary>
+    [JsonProperty("isResolved")]
+    public bool IsResolved { get; set; }
+
+    /// <summary>
+    /// Order of this column on board, counting from left to right.
+    /// </summary>
+    [JsonProperty("ordinal")]
+    public int Ordinal { get; set; }
+
+    /// <summary>
+    /// WIP limit for this column. Can be null.
+    /// </summary>
+    [JsonProperty("wipLimit")]
+    public WIPLimit WipLimit { get; set; }
+
+    /// <summary>
+    /// Field values represented by this column.
+    /// </summary>
+    [JsonProperty("fieldValues")]
+    public List<AgileColumnFieldValue> FieldValues { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/AgileColumn.cs
+++ b/src/YouTrackSharp/Agiles/AgileColumn.cs
@@ -1,45 +1,47 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents settings for a single board column
-  /// </summary>
-  public class AgileColumn {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the AgileColumn.
+    /// Represents settings for a single board column
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class AgileColumn
+    {
+        /// <summary>
+        /// Id of the AgileColumn.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Text presentation of values stored in a column. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("presentation")]
-    public string Presentation { get; set; }
+        /// <summary>
+        /// Text presentation of values stored in a column. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("presentation")]
+        public string Presentation { get; set; }
 
-    /// <summary>
-    /// true if a column represents resolved state of an issue. Can be updated only for newly created value. Read-only.
-    /// </summary>
-    [JsonProperty("isResolved")]
-    public bool IsResolved { get; set; }
+        /// <summary>
+        /// true if a column represents resolved state of an issue. Can be updated only for newly created value. Read-only.
+        /// </summary>
+        [JsonProperty("isResolved")]
+        public bool IsResolved { get; set; }
 
-    /// <summary>
-    /// Order of this column on board, counting from left to right.
-    /// </summary>
-    [JsonProperty("ordinal")]
-    public int Ordinal { get; set; }
+        /// <summary>
+        /// Order of this column on board, counting from left to right.
+        /// </summary>
+        [JsonProperty("ordinal")]
+        public int Ordinal { get; set; }
 
-    /// <summary>
-    /// WIP limit for this column. Can be null.
-    /// </summary>
-    [JsonProperty("wipLimit")]
-    public WIPLimit WipLimit { get; set; }
+        /// <summary>
+        /// WIP limit for this column. Can be null.
+        /// </summary>
+        [JsonProperty("wipLimit")]
+        public WIPLimit WipLimit { get; set; }
 
-    /// <summary>
-    /// Field values represented by this column.
-    /// </summary>
-    [JsonProperty("fieldValues")]
-    public List<AgileColumnFieldValue> FieldValues { get; set; }
-  }
+        /// <summary>
+        /// Field values represented by this column.
+        /// </summary>
+        [JsonProperty("fieldValues")]
+        public List<AgileColumnFieldValue> FieldValues { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/AgileColumnFieldValue.cs
+++ b/src/YouTrackSharp/Agiles/AgileColumnFieldValue.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a field value or values, parameterizing agile column.
+  /// </summary>
+  public class AgileColumnFieldValue : DatabaseAttributeValue {
+    /// <summary>
+    /// Presentation of a field value or values. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// True, if field has type State and teh value is resolved or all values are resolved. Read-only.
+    /// </summary>
+    [JsonProperty("isResolved")]
+    public bool IsResolved { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/AgileColumnFieldValue.cs
+++ b/src/YouTrackSharp/Agiles/AgileColumnFieldValue.cs
@@ -1,20 +1,22 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a field value or values, parameterizing agile column.
-  /// </summary>
-  public class AgileColumnFieldValue : DatabaseAttributeValue {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Presentation of a field value or values. Can be null.
+    /// Represents a field value or values, parameterizing agile column.
     /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
+    public class AgileColumnFieldValue : DatabaseAttributeValue
+    {
+        /// <summary>
+        /// Presentation of a field value or values. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-    /// <summary>
-    /// True, if field has type State and teh value is resolved or all values are resolved. Read-only.
-    /// </summary>
-    [JsonProperty("isResolved")]
-    public bool IsResolved { get; set; }
-  }
+        /// <summary>
+        /// True, if field has type State and teh value is resolved or all values are resolved. Read-only.
+        /// </summary>
+        [JsonProperty("isResolved")]
+        public bool IsResolved { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/AgileService.cs
+++ b/src/YouTrackSharp/Agiles/AgileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -35,15 +36,15 @@ namespace YouTrackSharp.Agiles
         {
             HttpClient client = await _connection.GetAuthenticatedHttpClient();
 
-            const int batchSize = 50;
+            const int batchSize = 10;
             List<Agile> agileBoards = new List<Agile>();
             List<Agile> currentBatch;
-
+            
             do
             {
                 string fields = _fieldSyntaxEncoder.Encode(typeof(Agile), verbose);
 
-                HttpResponseMessage message = await client.GetAsync($"api/agiles?fields={fields}");
+                HttpResponseMessage message = await client.GetAsync($"api/agiles?fields={fields}&$top={batchSize}&$skip={agileBoards.Count}");
 
                 string response = await message.Content.ReadAsStringAsync();
 

--- a/src/YouTrackSharp/Agiles/AgileService.cs
+++ b/src/YouTrackSharp/Agiles/AgileService.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using YouTrackSharp.Internal;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Service offering Agile-related operations. 
+  /// </summary>
+  public class AgileService : IAgileService {
+    private readonly Connection _connection;
+
+    private readonly FieldSyntaxEncoder _fieldSyntaxEncoder;
+
+    /// <summary>
+    /// Creates an instance of the <see cref="AgileService"/> class.
+    /// </summary>
+    /// <param name="connection">
+    /// A <see cref="Connection" /> instance that provides a connection to the remote YouTrack server instance.
+    /// </param>
+    /// <param name="fieldSyntaxEncoder">
+    /// An <see cref="FieldSyntaxEncoder"/> instance that allows to encode types into Youtrack request URL format for fields 
+    /// </param>
+    public AgileService(Connection connection, FieldSyntaxEncoder fieldSyntaxEncoder) {
+      _connection = connection;
+      _fieldSyntaxEncoder = fieldSyntaxEncoder;
+    }
+
+    /// <inheritdoc />
+    public async Task<ICollection<Agile>> GetAgileBoards(bool verbose = false) {
+      HttpClient client = await _connection.GetAuthenticatedHttpClient();
+
+      const int batchSize = 50;
+      List<Agile> agileBoards = new List<Agile>();
+      List<Agile> currentBatch;
+
+      do {
+        string fields = _fieldSyntaxEncoder.Encode(typeof(Agile), verbose);
+        
+        HttpResponseMessage message = await client.GetAsync($"api/agiles?fields={fields}");
+
+        string response = await message.Content.ReadAsStringAsync();
+
+        currentBatch = JsonConvert.DeserializeObject<List<Agile>>(response);
+
+        agileBoards.AddRange(currentBatch);
+      } while (currentBatch.Count == batchSize);
+
+      return agileBoards;
+    }
+  }
+}

--- a/src/YouTrackSharp/Agiles/AgileService.cs
+++ b/src/YouTrackSharp/Agiles/AgileService.cs
@@ -4,50 +4,55 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using YouTrackSharp.Internal;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Service offering Agile-related operations. 
-  /// </summary>
-  public class AgileService : IAgileService {
-    private readonly Connection _connection;
-
-    private readonly FieldSyntaxEncoder _fieldSyntaxEncoder;
-
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Creates an instance of the <see cref="AgileService"/> class.
+    /// Service offering Agile-related operations. 
     /// </summary>
-    /// <param name="connection">
-    /// A <see cref="Connection" /> instance that provides a connection to the remote YouTrack server instance.
-    /// </param>
-    /// <param name="fieldSyntaxEncoder">
-    /// An <see cref="FieldSyntaxEncoder"/> instance that allows to encode types into Youtrack request URL format for fields 
-    /// </param>
-    public AgileService(Connection connection, FieldSyntaxEncoder fieldSyntaxEncoder) {
-      _connection = connection;
-      _fieldSyntaxEncoder = fieldSyntaxEncoder;
+    public class AgileService : IAgileService
+    {
+        private readonly Connection _connection;
+
+        private readonly FieldSyntaxEncoder _fieldSyntaxEncoder;
+
+        /// <summary>
+        /// Creates an instance of the <see cref="AgileService"/> class.
+        /// </summary>
+        /// <param name="connection">
+        /// A <see cref="Connection" /> instance that provides a connection to the remote YouTrack server instance.
+        /// </param>
+        /// <param name="fieldSyntaxEncoder">
+        /// An <see cref="FieldSyntaxEncoder"/> instance that allows to encode types into Youtrack request URL format for fields 
+        /// </param>
+        public AgileService(Connection connection, FieldSyntaxEncoder fieldSyntaxEncoder)
+        {
+            _connection = connection;
+            _fieldSyntaxEncoder = fieldSyntaxEncoder;
+        }
+
+        /// <inheritdoc />
+        public async Task<ICollection<Agile>> GetAgileBoards(bool verbose = false)
+        {
+            HttpClient client = await _connection.GetAuthenticatedHttpClient();
+
+            const int batchSize = 50;
+            List<Agile> agileBoards = new List<Agile>();
+            List<Agile> currentBatch;
+
+            do
+            {
+                string fields = _fieldSyntaxEncoder.Encode(typeof(Agile), verbose);
+
+                HttpResponseMessage message = await client.GetAsync($"api/agiles?fields={fields}");
+
+                string response = await message.Content.ReadAsStringAsync();
+
+                currentBatch = JsonConvert.DeserializeObject<List<Agile>>(response);
+
+                agileBoards.AddRange(currentBatch);
+            } while (currentBatch.Count == batchSize);
+
+            return agileBoards;
+        }
     }
-
-    /// <inheritdoc />
-    public async Task<ICollection<Agile>> GetAgileBoards(bool verbose = false) {
-      HttpClient client = await _connection.GetAuthenticatedHttpClient();
-
-      const int batchSize = 50;
-      List<Agile> agileBoards = new List<Agile>();
-      List<Agile> currentBatch;
-
-      do {
-        string fields = _fieldSyntaxEncoder.Encode(typeof(Agile), verbose);
-        
-        HttpResponseMessage message = await client.GetAsync($"api/agiles?fields={fields}");
-
-        string response = await message.Content.ReadAsStringAsync();
-
-        currentBatch = JsonConvert.DeserializeObject<List<Agile>>(response);
-
-        agileBoards.AddRange(currentBatch);
-      } while (currentBatch.Count == batchSize);
-
-      return agileBoards;
-    }
-  }
 }

--- a/src/YouTrackSharp/Agiles/AgileStatus.cs
+++ b/src/YouTrackSharp/Agiles/AgileStatus.cs
@@ -1,40 +1,42 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Shows if the board has any configuration problems.
-  /// </summary>
-  public class AgileStatus {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the AgileStatus.
+    /// Shows if the board has any configuration problems.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class AgileStatus
+    {
+        /// <summary>
+        /// Id of the AgileStatus.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// true if the board is in valid state and can be used. Read-only.
-    /// </summary>
-    [JsonProperty("valid")]
-    public bool Valid { get; set; }
+        /// <summary>
+        /// true if the board is in valid state and can be used. Read-only.
+        /// </summary>
+        [JsonProperty("valid")]
+        public bool Valid { get; set; }
 
-    /// <summary>
-    /// If `true`, then a background job is currently being executed for the board. In this case, while a background
-    /// job is running, the board cannot be updated. Read-only.
-    /// </summary>
-    [JsonProperty("hasJobs")]
-    public bool HasJobs { get; set; }
+        /// <summary>
+        /// If `true`, then a background job is currently being executed for the board. In this case, while a background
+        /// job is running, the board cannot be updated. Read-only.
+        /// </summary>
+        [JsonProperty("hasJobs")]
+        public bool HasJobs { get; set; }
 
-    /// <summary>
-    /// List of configuration errors found for this board. Read-only.
-    /// </summary>
-    [JsonProperty("errors")]
-    public List<string> Errors { get; set; }
+        /// <summary>
+        /// List of configuration errors found for this board. Read-only.
+        /// </summary>
+        [JsonProperty("errors")]
+        public List<string> Errors { get; set; }
 
-    /// <summary>
-    /// List of configuration-related warnings found for this board. Read-only.
-    /// </summary>
-    [JsonProperty("warnings")]
-    public List<string> Warnings { get; set; }
-  }
+        /// <summary>
+        /// List of configuration-related warnings found for this board. Read-only.
+        /// </summary>
+        [JsonProperty("warnings")]
+        public List<string> Warnings { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/AgileStatus.cs
+++ b/src/YouTrackSharp/Agiles/AgileStatus.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Shows if the board has any configuration problems.
+  /// </summary>
+  public class AgileStatus {
+    /// <summary>
+    /// Id of the AgileStatus.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// true if the board is in valid state and can be used. Read-only.
+    /// </summary>
+    [JsonProperty("valid")]
+    public bool Valid { get; set; }
+
+    /// <summary>
+    /// If `true`, then a background job is currently being executed for the board. In this case, while a background
+    /// job is running, the board cannot be updated. Read-only.
+    /// </summary>
+    [JsonProperty("hasJobs")]
+    public bool HasJobs { get; set; }
+
+    /// <summary>
+    /// List of configuration errors found for this board. Read-only.
+    /// </summary>
+    [JsonProperty("errors")]
+    public List<string> Errors { get; set; }
+
+    /// <summary>
+    /// List of configuration-related warnings found for this board. Read-only.
+    /// </summary>
+    [JsonProperty("warnings")]
+    public List<string> Warnings { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Settings of swimlanes that are identified by the set of values in the selected field. For example, you can set
+  /// swimlanes to represent issues for each Assignee.
+  /// </summary>
+  public class AttributeBasedSwimlaneSettings : SwimlaneSettings {
+    /// <summary>
+    /// CustomField which values are used to identify swimlane.
+    /// </summary>
+    [JsonProperty("field")]
+    public FilterField Field { get; set; }
+
+    /// <summary>
+    /// Swimlanes that are visible on the Board.
+    /// </summary>
+    [JsonProperty("values")]
+    public List<SwimlaneEntityAttributeValue> Values { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using YouTrackSharp.Json;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
@@ -11,6 +12,7 @@ namespace YouTrackSharp.Agiles {
     /// CustomField which values are used to identify swimlane.
     /// </summary>
     [JsonProperty("field")]
+    [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
     public FilterField Field { get; set; }
 
     /// <summary>

--- a/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/AttributeBasedSwimlaneSettings.cs
@@ -2,23 +2,25 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using YouTrackSharp.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Settings of swimlanes that are identified by the set of values in the selected field. For example, you can set
-  /// swimlanes to represent issues for each Assignee.
-  /// </summary>
-  public class AttributeBasedSwimlaneSettings : SwimlaneSettings {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// CustomField which values are used to identify swimlane.
+    /// Settings of swimlanes that are identified by the set of values in the selected field. For example, you can set
+    /// swimlanes to represent issues for each Assignee.
     /// </summary>
-    [JsonProperty("field")]
-    [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
-    public FilterField Field { get; set; }
+    public class AttributeBasedSwimlaneSettings : SwimlaneSettings
+    {
+        /// <summary>
+        /// CustomField which values are used to identify swimlane.
+        /// </summary>
+        [JsonProperty("field")]
+        [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
+        public FilterField Field { get; set; }
 
-    /// <summary>
-    /// Swimlanes that are visible on the Board.
-    /// </summary>
-    [JsonProperty("values")]
-    public List<SwimlaneEntityAttributeValue> Values { get; set; }
-  }
+        /// <summary>
+        /// Swimlanes that are visible on the Board.
+        /// </summary>
+        [JsonProperty("values")]
+        public List<SwimlaneEntityAttributeValue> Values { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/ColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/ColorCoding.cs
@@ -1,18 +1,19 @@
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Agiles {
-  
-  /// <summary>
-  /// Describe rules according to which different colors are used for cards on agile board.
-  /// </summary>
-  [KnownType(typeof(FieldBasedColorCoding))]
-  [KnownType(typeof(ProjectBasedColorCoding))]
-  public class ColorCoding {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the ColorCoding.
+    /// Describe rules according to which different colors are used for cards on agile board.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
-  }
+    [KnownType(typeof(FieldBasedColorCoding))]
+    [KnownType(typeof(ProjectBasedColorCoding))]
+    public class ColorCoding
+    {
+        /// <summary>
+        /// Id of the ColorCoding.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/ColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/ColorCoding.cs
@@ -1,10 +1,13 @@
 using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
 
 namespace YouTrackSharp.Agiles {
   
   /// <summary>
   /// Describe rules according to which different colors are used for cards on agile board.
   /// </summary>
+  [KnownType(typeof(FieldBasedColorCoding))]
+  [KnownType(typeof(ProjectBasedColorCoding))]
   public class ColorCoding {
     /// <summary>
     /// Id of the ColorCoding.

--- a/src/YouTrackSharp/Agiles/ColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/ColorCoding.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  
+  /// <summary>
+  /// Describe rules according to which different colors are used for cards on agile board.
+  /// </summary>
+  public class ColorCoding {
+    /// <summary>
+    /// Id of the ColorCoding.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/ColumnSettings.cs
+++ b/src/YouTrackSharp/Agiles/ColumnSettings.cs
@@ -2,27 +2,29 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using YouTrackSharp.Projects;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Agile board columns settings.
-  /// </summary>
-  public class ColumnSettings {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the ColumnSettings.
+    /// Agile board columns settings.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class ColumnSettings
+    {
+        /// <summary>
+        /// Id of the ColumnSettings.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Custom field, which values are used for columns. Can be null.
-    /// </summary>
-    [JsonProperty("field")]
-    public CustomField Field { get; set; }
+        /// <summary>
+        /// Custom field, which values are used for columns. Can be null.
+        /// </summary>
+        [JsonProperty("field")]
+        public CustomField Field { get; set; }
 
-    /// <summary>
-    /// Columns that are shown on the board.
-    /// </summary>
-    [JsonProperty("columns")]
-    public List<AgileColumn> Columns { get; set; }
-  }
+        /// <summary>
+        /// Columns that are shown on the board.
+        /// </summary>
+        [JsonProperty("columns")]
+        public List<AgileColumn> Columns { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/ColumnSettings.cs
+++ b/src/YouTrackSharp/Agiles/ColumnSettings.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using YouTrackSharp.Projects;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Agile board columns settings.
+  /// </summary>
+  public class ColumnSettings {
+    /// <summary>
+    /// Id of the ColumnSettings.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Custom field, which values are used for columns. Can be null.
+    /// </summary>
+    [JsonProperty("field")]
+    public CustomField Field { get; set; }
+
+    /// <summary>
+    /// Columns that are shown on the board.
+    /// </summary>
+    [JsonProperty("columns")]
+    public List<AgileColumn> Columns { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/CustomFilterField.cs
+++ b/src/YouTrackSharp/Agiles/CustomFilterField.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+using YouTrackSharp.Projects;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a custom field of the issue.
+  /// </summary>
+  public class CustomFilterField : FilterField {
+    /// <summary>
+    /// Reference to settings of the custom field. Read-only.
+    /// </summary>
+    [JsonProperty("customField")]
+    public CustomField CustomField { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/CustomFilterField.cs
+++ b/src/YouTrackSharp/Agiles/CustomFilterField.cs
@@ -1,15 +1,17 @@
 using Newtonsoft.Json;
 using YouTrackSharp.Projects;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a custom field of the issue.
-  /// </summary>
-  public class CustomFilterField : FilterField {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Reference to settings of the custom field. Read-only.
+    /// Represents a custom field of the issue.
     /// </summary>
-    [JsonProperty("customField")]
-    public CustomField CustomField { get; set; }
-  }
+    public class CustomFilterField : FilterField
+    {
+        /// <summary>
+        /// Reference to settings of the custom field. Read-only.
+        /// </summary>
+        [JsonProperty("customField")]
+        public CustomField CustomField { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
+++ b/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
@@ -1,9 +1,12 @@
 using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
   /// Represents string reference to the value.
   /// </summary>
+  [KnownType(typeof(SwimlaneEntityAttributeValue))]
+  [KnownType(typeof(AgileColumnFieldValue))]
   public class DatabaseAttributeValue {
     /// <summary>
     /// Id of the DatabaseAttributeValue.

--- a/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
+++ b/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
@@ -1,17 +1,19 @@
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents string reference to the value.
-  /// </summary>
-  [KnownType(typeof(SwimlaneEntityAttributeValue))]
-  [KnownType(typeof(AgileColumnFieldValue))]
-  public class DatabaseAttributeValue {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the DatabaseAttributeValue.
+    /// Represents string reference to the value.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
-  }
+    [KnownType(typeof(SwimlaneEntityAttributeValue))]
+    [KnownType(typeof(AgileColumnFieldValue))]
+    public class DatabaseAttributeValue
+    {
+        /// <summary>
+        /// Id of the DatabaseAttributeValue.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
+++ b/src/YouTrackSharp/Agiles/DatabaseAttributeValue.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents string reference to the value.
+  /// </summary>
+  public class DatabaseAttributeValue {
+    /// <summary>
+    /// Id of the DatabaseAttributeValue.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/FieldBasedColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/FieldBasedColorCoding.cs
@@ -1,15 +1,17 @@
 using Newtonsoft.Json;
 using YouTrackSharp.Projects;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Allows to set card's color based on a value of some custom field.
-  /// </summary>
-  public class FieldBasedColorCoding : ColorCoding {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Sets card color based on this custom field. Can be null.
+    /// Allows to set card's color based on a value of some custom field.
     /// </summary>
-    [JsonProperty("prototype")]
-    public CustomField Prototype { get; set; }
-  }
+    public class FieldBasedColorCoding : ColorCoding
+    {
+        /// <summary>
+        /// Sets card color based on this custom field. Can be null.
+        /// </summary>
+        [JsonProperty("prototype")]
+        public CustomField Prototype { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/FieldBasedColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/FieldBasedColorCoding.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+using YouTrackSharp.Projects;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Allows to set card's color based on a value of some custom field.
+  /// </summary>
+  public class FieldBasedColorCoding : ColorCoding {
+    /// <summary>
+    /// Sets card color based on this custom field. Can be null.
+    /// </summary>
+    [JsonProperty("prototype")]
+    public CustomField Prototype { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/FieldStyle.cs
+++ b/src/YouTrackSharp/Agiles/FieldStyle.cs
@@ -1,26 +1,28 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents the style settings of the field in YouTrack.
-  /// </summary>
-  public class FieldStyle {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the FieldStyle.
+    /// Represents the style settings of the field in YouTrack.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class FieldStyle
+    {
+        /// <summary>
+        /// Id of the FieldStyle.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Background color. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("background")]
-    public string Background { get; set; }
+        /// <summary>
+        /// Background color. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("background")]
+        public string Background { get; set; }
 
-    /// <summary>
-    /// Foreground color. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("foreground")]
-    public string Foreground { get; set; }
-  }
+        /// <summary>
+        /// Foreground color. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("foreground")]
+        public string Foreground { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/FieldStyle.cs
+++ b/src/YouTrackSharp/Agiles/FieldStyle.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents the style settings of the field in YouTrack.
+  /// </summary>
+  public class FieldStyle {
+    /// <summary>
+    /// Id of the FieldStyle.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Background color. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("background")]
+    public string Background { get; set; }
+
+    /// <summary>
+    /// Foreground color. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("foreground")]
+    public string Foreground { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/FilterField.cs
+++ b/src/YouTrackSharp/Agiles/FilterField.cs
@@ -1,9 +1,12 @@
 using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
   /// Represents an issue property, which can be a predefined field, a custom field, a link, and so on.
   /// </summary>
+  [KnownType(typeof(PredefinedFilterField))]
+  [KnownType(typeof(CustomFilterField))]
   public class FilterField {
     /// <summary>
     /// Id of the FilterField.

--- a/src/YouTrackSharp/Agiles/FilterField.cs
+++ b/src/YouTrackSharp/Agiles/FilterField.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents an issue property, which can be a predefined field, a custom field, a link, and so on.
+  /// </summary>
+  public class FilterField {
+    /// <summary>
+    /// Id of the FilterField.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Presentation of the field. Read-only.
+    /// </summary>
+    [JsonProperty("presentation")]
+    public string Presentation { get; set; }
+
+    /// <summary>
+    /// The name of the field. Read-only.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/FilterField.cs
+++ b/src/YouTrackSharp/Agiles/FilterField.cs
@@ -1,29 +1,31 @@
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents an issue property, which can be a predefined field, a custom field, a link, and so on.
-  /// </summary>
-  [KnownType(typeof(PredefinedFilterField))]
-  [KnownType(typeof(CustomFilterField))]
-  public class FilterField {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the FilterField.
+    /// Represents an issue property, which can be a predefined field, a custom field, a link, and so on.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    [KnownType(typeof(PredefinedFilterField))]
+    [KnownType(typeof(CustomFilterField))]
+    public class FilterField
+    {
+        /// <summary>
+        /// Id of the FilterField.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Presentation of the field. Read-only.
-    /// </summary>
-    [JsonProperty("presentation")]
-    public string Presentation { get; set; }
+        /// <summary>
+        /// Presentation of the field. Read-only.
+        /// </summary>
+        [JsonProperty("presentation")]
+        public string Presentation { get; set; }
 
-    /// <summary>
-    /// The name of the field. Read-only.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-  }
+        /// <summary>
+        /// The name of the field. Read-only.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/IAgileService.cs
+++ b/src/YouTrackSharp/Agiles/IAgileService.cs
@@ -1,25 +1,27 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace YouTrackSharp.Agiles {
-  public interface IAgileService {
-    /// <summary>
-    /// Retrieves the available agile boards from the server.
-    /// </summary>
-    /// <param name="verbose">
-    /// If the full representation of agile boards should be returned.
-    /// If this parameter is <c>false</c>, all the fields (and sub-fields) marked with the
-    /// <see cref="YouTrackSharp.SerializationAttributes.VerboseAttribute"/> are omitted (for more information, see
-    /// <see cref="Agile"/> and related classes).
-    /// </param>
-    /// <remarks>
-    /// Uses the REST API
-    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/resource-api-agiles.html#get_all-Agile-method">
-    /// Read a list of Agiles
-    /// </a>
-    /// </remarks>
-    /// <returns>A <see cref="ICollection{T}"/> of available <see cref="Agile"/> boards</returns>
-    /// <exception cref="T:System.Net.HttpRequestException">When the call to the remote YouTrack server instance failed.</exception>
-    public Task<ICollection<Agile>> GetAgileBoards(bool verbose = false);
-  }
+namespace YouTrackSharp.Agiles
+{
+    public interface IAgileService
+    {
+        /// <summary>
+        /// Retrieves the available agile boards from the server.
+        /// </summary>
+        /// <param name="verbose">
+        /// If the full representation of agile boards should be returned.
+        /// If this parameter is <c>false</c>, all the fields (and sub-fields) marked with the
+        /// <see cref="YouTrackSharp.SerializationAttributes.VerboseAttribute"/> are omitted (for more information, see
+        /// <see cref="Agile"/> and related classes).
+        /// </param>
+        /// <remarks>
+        /// Uses the REST API
+        /// <a href="https://www.jetbrains.com/help/youtrack/standalone/resource-api-agiles.html#get_all-Agile-method">
+        /// Read a list of Agiles
+        /// </a>
+        /// </remarks>
+        /// <returns>A <see cref="ICollection{T}"/> of available <see cref="Agile"/> boards</returns>
+        /// <exception cref="T:System.Net.HttpRequestException">When the call to the remote YouTrack server instance failed.</exception>
+        public Task<ICollection<Agile>> GetAgileBoards(bool verbose = false);
+    }
 }

--- a/src/YouTrackSharp/Agiles/IAgileService.cs
+++ b/src/YouTrackSharp/Agiles/IAgileService.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace YouTrackSharp.Agiles {
+  public interface IAgileService {
+    /// <summary>
+    /// Retrieves the available agile boards from the server.
+    /// </summary>
+    /// <param name="verbose">
+    /// If the full representation of agile boards should be returned.
+    /// If this parameter is <c>false</c>, all the fields (and sub-fields) marked with the
+    /// <see cref="YouTrackSharp.SerializationAttributes.VerboseAttribute"/> are omitted (for more information, see
+    /// <see cref="Agile"/> and related classes).
+    /// </param>
+    /// <remarks>
+    /// Uses the REST API
+    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/resource-api-agiles.html#get_all-Agile-method">
+    /// Read a list of Agiles
+    /// </a>
+    /// </remarks>
+    /// <returns>A <see cref="ICollection{T}"/> of available <see cref="Agile"/> boards</returns>
+    /// <exception cref="T:System.Net.HttpRequestException">When the call to the remote YouTrack server instance failed.</exception>
+    public Task<ICollection<Agile>> GetAgileBoards(bool verbose = false);
+  }
+}

--- a/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Base entity for different swimlane settings
+  /// </summary>
+  public class IssueBasedSwimlaneSettings : SwimlaneSettings {
+    /// <summary>
+    /// CustomField which values are used to identify swimlane.
+    /// </summary>
+    [JsonProperty("field")]
+    public FilterField Field { get; set; }
+
+    /// <summary>
+    /// Value of a field that a card would have by default. Can be null.
+    /// </summary>
+    [JsonProperty("defaultCardType")]
+    public SwimlaneValue DefaultCardType { get; set; }
+
+    /// <summary>
+    /// When issue has one of this values, it becomes a swimlane on this board.
+    /// </summary>
+    [JsonProperty("values")]
+    public List<SwimlaneValue> Values { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using YouTrackSharp.Json;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
@@ -10,6 +11,7 @@ namespace YouTrackSharp.Agiles {
     /// CustomField which values are used to identify swimlane.
     /// </summary>
     [JsonProperty("field")]
+    [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
     public FilterField Field { get; set; }
 
     /// <summary>

--- a/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/IssueBasedSwimlaneSettings.cs
@@ -2,28 +2,30 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using YouTrackSharp.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Base entity for different swimlane settings
-  /// </summary>
-  public class IssueBasedSwimlaneSettings : SwimlaneSettings {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// CustomField which values are used to identify swimlane.
+    /// Base entity for different swimlane settings
     /// </summary>
-    [JsonProperty("field")]
-    [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
-    public FilterField Field { get; set; }
+    public class IssueBasedSwimlaneSettings : SwimlaneSettings
+    {
+        /// <summary>
+        /// CustomField which values are used to identify swimlane.
+        /// </summary>
+        [JsonProperty("field")]
+        [JsonConverter(typeof(KnownTypeConverter<FilterField>))]
+        public FilterField Field { get; set; }
 
-    /// <summary>
-    /// Value of a field that a card would have by default. Can be null.
-    /// </summary>
-    [JsonProperty("defaultCardType")]
-    public SwimlaneValue DefaultCardType { get; set; }
+        /// <summary>
+        /// Value of a field that a card would have by default. Can be null.
+        /// </summary>
+        [JsonProperty("defaultCardType")]
+        public SwimlaneValue DefaultCardType { get; set; }
 
-    /// <summary>
-    /// When issue has one of this values, it becomes a swimlane on this board.
-    /// </summary>
-    [JsonProperty("values")]
-    public List<SwimlaneValue> Values { get; set; }
-  }
+        /// <summary>
+        /// When issue has one of this values, it becomes a swimlane on this board.
+        /// </summary>
+        [JsonProperty("values")]
+        public List<SwimlaneValue> Values { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/PredefinedFilterField.cs
+++ b/src/YouTrackSharp/Agiles/PredefinedFilterField.cs
@@ -1,8 +1,9 @@
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a predefined field of the issue. Predefined fields are always present in an issue and |cannot be
-  /// customized in a project. For example, project, created, |updated, tags, and so on.
-  /// </summary>
-  public class PredefinedFilterField : FilterField {
-  }
+namespace YouTrackSharp.Agiles
+{
+    /// <summary>
+    /// Represents a predefined field of the issue. Predefined fields are always present in an issue and |cannot be
+    /// customized in a project. For example, project, created, |updated, tags, and so on.
+    /// </summary>
+    public class PredefinedFilterField : FilterField
+    { }
 }

--- a/src/YouTrackSharp/Agiles/PredefinedFilterField.cs
+++ b/src/YouTrackSharp/Agiles/PredefinedFilterField.cs
@@ -1,0 +1,8 @@
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a predefined field of the issue. Predefined fields are always present in an issue and |cannot be
+  /// customized in a project. For example, project, created, |updated, tags, and so on.
+  /// </summary>
+  public class PredefinedFilterField : FilterField {
+  }
+}

--- a/src/YouTrackSharp/Agiles/Project.cs
+++ b/src/YouTrackSharp/Agiles/Project.cs
@@ -1,27 +1,29 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a project in the context of an agile board. The class only provides the id, short name and name of the
-  /// project see <see cref="ProjectService"/> for more info on how to access a YouTrack project.
-  /// </summary>
-  public class Project {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the Project.
+    /// Represents a project in the context of an agile board. The class only provides the id, short name and name of the
+    /// project see <see cref="ProjectService"/> for more info on how to access a YouTrack project.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class Project
+    {
+        /// <summary>
+        /// Id of the Project.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// The ID of the project. This short name is also a prefix for an issue ID. Can be null.
-    /// </summary>
-    [JsonProperty("shortName")]
-    public string ShortName { get; set; }
+        /// <summary>
+        /// The ID of the project. This short name is also a prefix for an issue ID. Can be null.
+        /// </summary>
+        [JsonProperty("shortName")]
+        public string ShortName { get; set; }
 
-    /// <summary>
-    /// The name of the issue folder. Can be null.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-  }
+        /// <summary>
+        /// The name of the issue folder. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/Project.cs
+++ b/src/YouTrackSharp/Agiles/Project.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a project in the context of an agile board. The class only provides the id, short name and name of the
+  /// project see <see cref="ProjectService"/> for more info on how to access a YouTrack project.
+  /// </summary>
+  public class Project {
+    /// <summary>
+    /// Id of the Project.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// The ID of the project. This short name is also a prefix for an issue ID. Can be null.
+    /// </summary>
+    [JsonProperty("shortName")]
+    public string ShortName { get; set; }
+
+    /// <summary>
+    /// The name of the issue folder. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/ProjectBasedColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/ProjectBasedColorCoding.cs
@@ -1,15 +1,17 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Allows to set card's color based on it's project
-  /// </summary>
-  public class ProjectBasedColorCoding : ColorCoding {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Collection of per-project color settings
+    /// Allows to set card's color based on it's project
     /// </summary>
-    [JsonProperty("projectColors")]
-    public List<ProjectColor> ProjectColors { get; set; }
-  }
+    public class ProjectBasedColorCoding : ColorCoding
+    {
+        /// <summary>
+        /// Collection of per-project color settings
+        /// </summary>
+        [JsonProperty("projectColors")]
+        public List<ProjectColor> ProjectColors { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/ProjectBasedColorCoding.cs
+++ b/src/YouTrackSharp/Agiles/ProjectBasedColorCoding.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Allows to set card's color based on it's project
+  /// </summary>
+  public class ProjectBasedColorCoding : ColorCoding {
+    /// <summary>
+    /// Collection of per-project color settings
+    /// </summary>
+    [JsonProperty("projectColors")]
+    public List<ProjectColor> ProjectColors { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/ProjectColor.cs
+++ b/src/YouTrackSharp/Agiles/ProjectColor.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represent color setting for one project on the board.
+  /// </summary>
+  public class ProjectColor {
+    /// <summary>
+    /// Id of the ProjectColor.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// A project, to which color this setting describes. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("project")]
+    public Project Project { get; set; }
+
+    /// <summary>
+    /// A color, that issues of this project will have on the board. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("color")]
+    public FieldStyle Color { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/ProjectColor.cs
+++ b/src/YouTrackSharp/Agiles/ProjectColor.cs
@@ -1,26 +1,28 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represent color setting for one project on the board.
-  /// </summary>
-  public class ProjectColor {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the ProjectColor.
+    /// Represent color setting for one project on the board.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class ProjectColor
+    {
+        /// <summary>
+        /// Id of the ProjectColor.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// A project, to which color this setting describes. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("project")]
-    public Project Project { get; set; }
+        /// <summary>
+        /// A project, to which color this setting describes. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("project")]
+        public Project Project { get; set; }
 
-    /// <summary>
-    /// A color, that issues of this project will have on the board. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("color")]
-    public FieldStyle Color { get; set; }
-  }
+        /// <summary>
+        /// A color, that issues of this project will have on the board. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("color")]
+        public FieldStyle Color { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/Sprint.cs
+++ b/src/YouTrackSharp/Agiles/Sprint.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a sprint in the context of an agile board. The class only provides the sprint's id and name, see <see
+  /// cref="SprintService"/> for more info on how to access a YouTrack sprint.
+  /// </summary>
+  public class Sprint {
+    /// <summary>
+    /// Id of the Sprint.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Name of the sprint. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/Sprint.cs
+++ b/src/YouTrackSharp/Agiles/Sprint.cs
@@ -1,21 +1,23 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a sprint in the context of an agile board. The class only provides the sprint's id and name, see <see
-  /// cref="SprintService"/> for more info on how to access a YouTrack sprint.
-  /// </summary>
-  public class Sprint {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the Sprint.
+    /// Represents a sprint in the context of an agile board. The class only provides the sprint's id and name, see <see
+    /// cref="SprintService"/> for more info on how to access a YouTrack sprint.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class Sprint
+    {
+        /// <summary>
+        /// Id of the Sprint.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Name of the sprint. Can be null.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-  }
+        /// <summary>
+        /// Name of the sprint. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/SprintsSettings.cs
+++ b/src/YouTrackSharp/Agiles/SprintsSettings.cs
@@ -1,62 +1,64 @@
 using Newtonsoft.Json;
 using YouTrackSharp.Projects;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Describes sprints configuration.
-  /// </summary>
-  public class SprintsSettings {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the SprintsSettings.
+    /// Describes sprints configuration.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class SprintsSettings
+    {
+        /// <summary>
+        /// Id of the SprintsSettings.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// If true, issues should be added to the board manually. If false, issues are shown on the board based on the
-    /// query and/or value of a field.
-    /// </summary>
-    [JsonProperty("isExplicit")]
-    public bool IsExplicit { get; set; }
+        /// <summary>
+        /// If true, issues should be added to the board manually. If false, issues are shown on the board based on the
+        /// query and/or value of a field.
+        /// </summary>
+        [JsonProperty("isExplicit")]
+        public bool IsExplicit { get; set; }
 
-    /// <summary>
-    /// If true, cards can be present on several sprints of this board.
-    /// </summary>
-    [JsonProperty("cardOnSeveralSprints")]
-    public bool CardOnSeveralSprints { get; set; }
+        /// <summary>
+        /// If true, cards can be present on several sprints of this board.
+        /// </summary>
+        [JsonProperty("cardOnSeveralSprints")]
+        public bool CardOnSeveralSprints { get; set; }
 
-    /// <summary>
-    /// New cards are added to this sprint by default. This setting applies only if isExplicit == true. Can be null.
-    /// </summary>
-    [JsonProperty("defaultSprint")]
-    public Sprint DefaultSprint { get; set; }
+        /// <summary>
+        /// New cards are added to this sprint by default. This setting applies only if isExplicit == true. Can be null.
+        /// </summary>
+        [JsonProperty("defaultSprint")]
+        public Sprint DefaultSprint { get; set; }
 
-    /// <summary>
-    /// If true, agile board has no distinct sprints in UI. However, in API it will look like it has only one active
-    /// (not-archived) sprint.
-    /// </summary>
-    [JsonProperty("disableSprints")]
-    public bool DisableSprints { get; set; }
+        /// <summary>
+        /// If true, agile board has no distinct sprints in UI. However, in API it will look like it has only one active
+        /// (not-archived) sprint.
+        /// </summary>
+        [JsonProperty("disableSprints")]
+        public bool DisableSprints { get; set; }
 
-    /// <summary>
-    /// Issues that match this query will appear on the board. This setting applies only if isExplicit == false. Can be
-    /// null.
-    /// </summary>
-    [JsonProperty("explicitQuery")]
-    public string ExplicitQuery { get; set; }
+        /// <summary>
+        /// Issues that match this query will appear on the board. This setting applies only if isExplicit == false. Can be
+        /// null.
+        /// </summary>
+        [JsonProperty("explicitQuery")]
+        public string ExplicitQuery { get; set; }
 
-    /// <summary>
-    /// Based on the value of this field, issues will be assigned to the sprints. This setting applies only if
-    /// isExplicit == false. Can be null.
-    /// </summary>
-    [JsonProperty("sprintSyncField")]
-    public CustomField SprintSyncField { get; set; }
+        /// <summary>
+        /// Based on the value of this field, issues will be assigned to the sprints. This setting applies only if
+        /// isExplicit == false. Can be null.
+        /// </summary>
+        [JsonProperty("sprintSyncField")]
+        public CustomField SprintSyncField { get; set; }
 
-    /// <summary>
-    /// If true, subtasks of the cards, that are present on the board, will be hidden if they match board query. This
-    /// setting applies only if isExplicit == false.
-    /// </summary>
-    [JsonProperty("hideSubtasksOfCards")]
-    public bool HideSubtasksOfCards { get; set; }
-  }
+        /// <summary>
+        /// If true, subtasks of the cards, that are present on the board, will be hidden if they match board query. This
+        /// setting applies only if isExplicit == false.
+        /// </summary>
+        [JsonProperty("hideSubtasksOfCards")]
+        public bool HideSubtasksOfCards { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/SprintsSettings.cs
+++ b/src/YouTrackSharp/Agiles/SprintsSettings.cs
@@ -1,0 +1,62 @@
+using Newtonsoft.Json;
+using YouTrackSharp.Projects;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Describes sprints configuration.
+  /// </summary>
+  public class SprintsSettings {
+    /// <summary>
+    /// Id of the SprintsSettings.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// If true, issues should be added to the board manually. If false, issues are shown on the board based on the
+    /// query and/or value of a field.
+    /// </summary>
+    [JsonProperty("isExplicit")]
+    public bool IsExplicit { get; set; }
+
+    /// <summary>
+    /// If true, cards can be present on several sprints of this board.
+    /// </summary>
+    [JsonProperty("cardOnSeveralSprints")]
+    public bool CardOnSeveralSprints { get; set; }
+
+    /// <summary>
+    /// New cards are added to this sprint by default. This setting applies only if isExplicit == true. Can be null.
+    /// </summary>
+    [JsonProperty("defaultSprint")]
+    public Sprint DefaultSprint { get; set; }
+
+    /// <summary>
+    /// If true, agile board has no distinct sprints in UI. However, in API it will look like it has only one active
+    /// (not-archived) sprint.
+    /// </summary>
+    [JsonProperty("disableSprints")]
+    public bool DisableSprints { get; set; }
+
+    /// <summary>
+    /// Issues that match this query will appear on the board. This setting applies only if isExplicit == false. Can be
+    /// null.
+    /// </summary>
+    [JsonProperty("explicitQuery")]
+    public string ExplicitQuery { get; set; }
+
+    /// <summary>
+    /// Based on the value of this field, issues will be assigned to the sprints. This setting applies only if
+    /// isExplicit == false. Can be null.
+    /// </summary>
+    [JsonProperty("sprintSyncField")]
+    public CustomField SprintSyncField { get; set; }
+
+    /// <summary>
+    /// If true, subtasks of the cards, that are present on the board, will be hidden if they match board query. This
+    /// setting applies only if isExplicit == false.
+    /// </summary>
+    [JsonProperty("hideSubtasksOfCards")]
+    public bool HideSubtasksOfCards { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/SwimlaneEntityAttributeValue.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneEntityAttributeValue.cs
@@ -1,21 +1,23 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a single swimlane in case of AttributeBasedSwimlaneSettings.
-  /// </summary>
-  public class SwimlaneEntityAttributeValue : DatabaseAttributeValue {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Name of the swimlane. Can be null.
+    /// Represents a single swimlane in case of AttributeBasedSwimlaneSettings.
     /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
+    public class SwimlaneEntityAttributeValue : DatabaseAttributeValue
+    {
+        /// <summary>
+        /// Name of the swimlane. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-    /// <summary>
-    /// If true, issues in this swimlane are considered to be resolved. Can be updated only for newly created value.
-    /// Read-only.
-    /// </summary>
-    [JsonProperty("isResolved")]
-    public bool IsResolved { get; set; }
-  }
+        /// <summary>
+        /// If true, issues in this swimlane are considered to be resolved. Can be updated only for newly created value.
+        /// Read-only.
+        /// </summary>
+        [JsonProperty("isResolved")]
+        public bool IsResolved { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/SwimlaneEntityAttributeValue.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneEntityAttributeValue.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a single swimlane in case of AttributeBasedSwimlaneSettings.
+  /// </summary>
+  public class SwimlaneEntityAttributeValue : DatabaseAttributeValue {
+    /// <summary>
+    /// Name of the swimlane. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// If true, issues in this swimlane are considered to be resolved. Can be updated only for newly created value.
+    /// Read-only.
+    /// </summary>
+    [JsonProperty("isResolved")]
+    public bool IsResolved { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Base entity for different swimlane settings
+  /// </summary>
+  public class SwimlaneSettings {
+    /// <summary>
+    /// Id of the SwimlaneSettings.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Name of a value. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
@@ -1,23 +1,25 @@
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Base entity for different swimlane settings
-  /// </summary>
-  [KnownType(typeof(AttributeBasedSwimlaneSettings))]
-  [KnownType(typeof(IssueBasedSwimlaneSettings))]
-  public class SwimlaneSettings {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the SwimlaneSettings.
+    /// Base entity for different swimlane settings
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    [KnownType(typeof(AttributeBasedSwimlaneSettings))]
+    [KnownType(typeof(IssueBasedSwimlaneSettings))]
+    public class SwimlaneSettings
+    {
+        /// <summary>
+        /// Id of the SwimlaneSettings.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Name of a value. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-  }
+        /// <summary>
+        /// Name of a value. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneSettings.cs
@@ -1,9 +1,12 @@
 using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
 
 namespace YouTrackSharp.Agiles {
   /// <summary>
   /// Base entity for different swimlane settings
   /// </summary>
+  [KnownType(typeof(AttributeBasedSwimlaneSettings))]
+  [KnownType(typeof(IssueBasedSwimlaneSettings))]
   public class SwimlaneSettings {
     /// <summary>
     /// Id of the SwimlaneSettings.

--- a/src/YouTrackSharp/Agiles/SwimlaneValue.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneValue.cs
@@ -1,20 +1,22 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents single swimlane in case of IssueBasedSwimlaneSettings.
-  /// </summary>
-  public class SwimlaneValue {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the SwimlaneValue.
+    /// Represents single swimlane in case of IssueBasedSwimlaneSettings.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class SwimlaneValue
+    {
+        /// <summary>
+        /// Id of the SwimlaneValue.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Name of a value. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-  }
+        /// <summary>
+        /// Name of a value. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/SwimlaneValue.cs
+++ b/src/YouTrackSharp/Agiles/SwimlaneValue.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents single swimlane in case of IssueBasedSwimlaneSettings.
+  /// </summary>
+  public class SwimlaneValue {
+    /// <summary>
+    /// Id of the SwimlaneValue.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Name of a value. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/User.cs
+++ b/src/YouTrackSharp/Agiles/User.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a user in the context of an agile board. The class only provides the id, ringId (hub ID) and full name
+  /// of the user, see <see cref="ManagementService"/> for more info on how to access a YouTrack user.
+  /// </summary>
+  public class User {
+    /// <summary>
+    /// Id of the User.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// ID of the user in Hub. You can use this ID for operations in Hub, and for matching users between YouTrack and
+    /// Hub. Read-only. Can be null.
+    /// </summary>
+    [JsonProperty("ringId")]
+    public string RingId { get; set; }
+
+    /// <summary>
+    /// Full name of the user.
+    /// </summary>
+    [JsonProperty("fullName")]
+    public string FullName { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/User.cs
+++ b/src/YouTrackSharp/Agiles/User.cs
@@ -1,28 +1,30 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a user in the context of an agile board. The class only provides the id, ringId (hub ID) and full name
-  /// of the user, see <see cref="ManagementService"/> for more info on how to access a YouTrack user.
-  /// </summary>
-  public class User {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the User.
+    /// Represents a user in the context of an agile board. The class only provides the id, ringId (hub ID) and full name
+    /// of the user, see <see cref="ManagementService"/> for more info on how to access a YouTrack user.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class User
+    {
+        /// <summary>
+        /// Id of the User.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// ID of the user in Hub. You can use this ID for operations in Hub, and for matching users between YouTrack and
-    /// Hub. Read-only. Can be null.
-    /// </summary>
-    [JsonProperty("ringId")]
-    public string RingId { get; set; }
+        /// <summary>
+        /// ID of the user in Hub. You can use this ID for operations in Hub, and for matching users between YouTrack and
+        /// Hub. Read-only. Can be null.
+        /// </summary>
+        [JsonProperty("ringId")]
+        public string RingId { get; set; }
 
-    /// <summary>
-    /// Full name of the user.
-    /// </summary>
-    [JsonProperty("fullName")]
-    public string FullName { get; set; }
-  }
+        /// <summary>
+        /// Full name of the user.
+        /// </summary>
+        [JsonProperty("fullName")]
+        public string FullName { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/UserGroup.cs
+++ b/src/YouTrackSharp/Agiles/UserGroup.cs
@@ -1,50 +1,52 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents a group of users.
-  /// </summary>
-  public class UserGroup {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the UserGroup.
+    /// Represents a group of users.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
-    
-    /// <summary>
-    /// The name of the group. Read-only. Can be null. 
-    /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
-    
-    /// <summary>
-    /// ID of the group in Hub. Use this ID for operations in Hub, and for matching groups between YouTrack and Hub. Read-only. Can be null.  
-    /// </summary>
-    [JsonProperty("ringId")]
-    public string RingId { get; set; }
-    
-    /// <summary>
-    /// The number of users in the group. Read-only. 
-    /// </summary>
-    [JsonProperty("userCount")]
-    public long UserCount { get; set; }
-    
-    /// <summary>
-    /// The URL of the group icon. Read-only. Can be null. 
-    /// </summary>
-    [JsonProperty("icon")]
-    public string Icon { get; set; }
-    
-    /// <summary>
-    /// True if this group contains all users, otherwise false. Read-only. 
-    /// </summary>
-    [JsonProperty("allUsersGroup")]
-    public bool AllUsersGroup { get; set; }
-    
-    /// <summary>
-    /// Project that has this group set as a team. Returns null, if there is no such project. Read-only. Can be null. 
-    /// </summary>
-    [JsonProperty("teamForProject")]
-    public Project TeamForProject { get; set; }
-  }
+    public class UserGroup
+    {
+        /// <summary>
+        /// Id of the UserGroup.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the group. Read-only. Can be null. 
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// ID of the group in Hub. Use this ID for operations in Hub, and for matching groups between YouTrack and Hub. Read-only. Can be null.  
+        /// </summary>
+        [JsonProperty("ringId")]
+        public string RingId { get; set; }
+
+        /// <summary>
+        /// The number of users in the group. Read-only. 
+        /// </summary>
+        [JsonProperty("userCount")]
+        public long UserCount { get; set; }
+
+        /// <summary>
+        /// The URL of the group icon. Read-only. Can be null. 
+        /// </summary>
+        [JsonProperty("icon")]
+        public string Icon { get; set; }
+
+        /// <summary>
+        /// True if this group contains all users, otherwise false. Read-only. 
+        /// </summary>
+        [JsonProperty("allUsersGroup")]
+        public bool AllUsersGroup { get; set; }
+
+        /// <summary>
+        /// Project that has this group set as a team. Returns null, if there is no such project. Read-only. Can be null. 
+        /// </summary>
+        [JsonProperty("teamForProject")]
+        public Project TeamForProject { get; set; }
+    }
 }

--- a/src/YouTrackSharp/Agiles/UserGroup.cs
+++ b/src/YouTrackSharp/Agiles/UserGroup.cs
@@ -1,0 +1,50 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents a group of users.
+  /// </summary>
+  public class UserGroup {
+    /// <summary>
+    /// Id of the UserGroup.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+    
+    /// <summary>
+    /// The name of the group. Read-only. Can be null. 
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+    
+    /// <summary>
+    /// ID of the group in Hub. Use this ID for operations in Hub, and for matching groups between YouTrack and Hub. Read-only. Can be null.  
+    /// </summary>
+    [JsonProperty("ringId")]
+    public string RingId { get; set; }
+    
+    /// <summary>
+    /// The number of users in the group. Read-only. 
+    /// </summary>
+    [JsonProperty("userCount")]
+    public long UserCount { get; set; }
+    
+    /// <summary>
+    /// The URL of the group icon. Read-only. Can be null. 
+    /// </summary>
+    [JsonProperty("icon")]
+    public string Icon { get; set; }
+    
+    /// <summary>
+    /// True if this group contains all users, otherwise false. Read-only. 
+    /// </summary>
+    [JsonProperty("allUsersGroup")]
+    public bool AllUsersGroup { get; set; }
+    
+    /// <summary>
+    /// Project that has this group set as a team. Returns null, if there is no such project. Read-only. Can be null. 
+    /// </summary>
+    [JsonProperty("teamForProject")]
+    public Project TeamForProject { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/WIPLimit.cs
+++ b/src/YouTrackSharp/Agiles/WIPLimit.cs
@@ -15,12 +15,12 @@ namespace YouTrackSharp.Agiles {
     /// Maximum number of cards in column. Can be null.
     /// </summary>
     [JsonProperty("max")]
-    public int Max { get; set; }
+    public int? Max { get; set; }
 
     /// <summary>
     /// Minimum number of cards in column. Can be null.
     /// </summary>
     [JsonProperty("min")]
-    public int Min { get; set; }
+    public int? Min { get; set; }
   }
 }

--- a/src/YouTrackSharp/Agiles/WIPLimit.cs
+++ b/src/YouTrackSharp/Agiles/WIPLimit.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace YouTrackSharp.Agiles {
+  /// <summary>
+  /// Represents WIP limits for particular column. If they are not satisfied, the column will be highlighted in UI.
+  /// </summary>
+  public class WIPLimit {
+    /// <summary>
+    /// Id of the WIPLimit.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Maximum number of cards in column. Can be null.
+    /// </summary>
+    [JsonProperty("max")]
+    public int Max { get; set; }
+
+    /// <summary>
+    /// Minimum number of cards in column. Can be null.
+    /// </summary>
+    [JsonProperty("min")]
+    public int Min { get; set; }
+  }
+}

--- a/src/YouTrackSharp/Agiles/WIPLimit.cs
+++ b/src/YouTrackSharp/Agiles/WIPLimit.cs
@@ -1,26 +1,28 @@
 using Newtonsoft.Json;
 
-namespace YouTrackSharp.Agiles {
-  /// <summary>
-  /// Represents WIP limits for particular column. If they are not satisfied, the column will be highlighted in UI.
-  /// </summary>
-  public class WIPLimit {
+namespace YouTrackSharp.Agiles
+{
     /// <summary>
-    /// Id of the WIPLimit.
+    /// Represents WIP limits for particular column. If they are not satisfied, the column will be highlighted in UI.
     /// </summary>
-    [JsonProperty("id")]
-    public string Id { get; set; }
+    public class WIPLimit
+    {
+        /// <summary>
+        /// Id of the WIPLimit.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-    /// <summary>
-    /// Maximum number of cards in column. Can be null.
-    /// </summary>
-    [JsonProperty("max")]
-    public int? Max { get; set; }
+        /// <summary>
+        /// Maximum number of cards in column. Can be null.
+        /// </summary>
+        [JsonProperty("max")]
+        public int? Max { get; set; }
 
-    /// <summary>
-    /// Minimum number of cards in column. Can be null.
-    /// </summary>
-    [JsonProperty("min")]
-    public int? Min { get; set; }
-  }
+        /// <summary>
+        /// Minimum number of cards in column. Can be null.
+        /// </summary>
+        [JsonProperty("min")]
+        public int? Min { get; set; }
+    }
 }

--- a/src/YouTrackSharp/ConnectionExtensions.cs
+++ b/src/YouTrackSharp/ConnectionExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using YouTrackSharp.AgileBoards;
+using YouTrackSharp.Agiles;
+using YouTrackSharp.Internal;
 using YouTrackSharp.Issues;
 using YouTrackSharp.Management;
 using YouTrackSharp.Projects;
@@ -70,6 +72,16 @@ namespace YouTrackSharp
         public static IProjectCustomFieldsService ProjectCustomFieldsService(this Connection connection)
         {
             return new ProjectCustomFieldsService(connection);
+        }
+        
+        /// <summary>
+        /// Creates a <see cref="AgileService"/>.
+        /// </summary>
+        /// <param name="connection">The <see cref="Connection" /> to create a service with.</param>
+        /// <returns><see cref="AgileBoardService" /> for working with YouTrack agile boards.</returns>
+        public static IAgileService CreateAgileService(this Connection connection)
+        {
+            return new AgileService(connection, new FieldSyntaxEncoder());
         }
 
         /// <summary>

--- a/src/YouTrackSharp/Internal/Field.cs
+++ b/src/YouTrackSharp/Internal/Field.cs
@@ -1,36 +1,39 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace YouTrackSharp.Internal {
-  /// <summary>
-  /// Simplified representation of an object's field.
-  /// It describes the name of the field and its sub-fields.
-  /// The 'subfields' are the members of the this field's type<br/>
-  /// </summary>
-  /// <remarks>
-  /// This class allows to encode the recursive structure of an object's fields.
-  /// An object's field has a type, which itself has other members, each being of a type, and so on, down to the
-  /// primitive types.<br/>
-  /// </remarks>
-  public class Field {
+namespace YouTrackSharp.Internal
+{
     /// <summary>
-    /// Name of the object's field
+    /// Simplified representation of an object's field.
+    /// It describes the name of the field and its sub-fields.
+    /// The 'subfields' are the members of the this field's type<br/>
     /// </summary>
-    public string Name { get; }
-    
-    /// <summary>
-    /// Sub-fields of this field's type
-    /// </summary>
-    public List<Field> Subfields { get; }
+    /// <remarks>
+    /// This class allows to encode the recursive structure of an object's fields.
+    /// An object's field has a type, which itself has other members, each being of a type, and so on, down to the
+    /// primitive types.<br/>
+    /// </remarks>
+    public class Field
+    {
+        /// <summary>
+        /// Name of the object's field
+        /// </summary>
+        public string Name { get; }
 
-    /// <summary>
-    /// Creates an instance of <see cref="Field"/>, with the given name, type and subfields.
-    /// </summary>
-    /// <param name="name">Name of the field</param>
-    /// <param name="subfields">Sub-fields of the field's type</param>
-    public Field(string name, IEnumerable<Field> subfields) {
-      Name = name;
-      Subfields = subfields.ToList();
+        /// <summary>
+        /// Sub-fields of this field's type
+        /// </summary>
+        public List<Field> Subfields { get; }
+
+        /// <summary>
+        /// Creates an instance of <see cref="Field"/>, with the given name, type and subfields.
+        /// </summary>
+        /// <param name="name">Name of the field</param>
+        /// <param name="subfields">Sub-fields of the field's type</param>
+        public Field(string name, IEnumerable<Field> subfields)
+        {
+            Name = name;
+            Subfields = subfields.ToList();
+        }
     }
-  }
 }

--- a/src/YouTrackSharp/Internal/Field.cs
+++ b/src/YouTrackSharp/Internal/Field.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace YouTrackSharp.Internal {
+  /// <summary>
+  /// Simplified representation of an object's field.
+  /// It describes the name of the field and its sub-fields.
+  /// The 'subfields' are the members of the this field's type<br/>
+  /// </summary>
+  /// <remarks>
+  /// This class allows to encode the recursive structure of an object's fields.
+  /// An object's field has a type, which itself has other members, each being of a type, and so on, down to the
+  /// primitive types.<br/>
+  /// </remarks>
+  public class Field {
+    /// <summary>
+    /// Name of the object's field
+    /// </summary>
+    public string Name { get; }
+    
+    /// <summary>
+    /// Sub-fields of this field's type
+    /// </summary>
+    public List<Field> Subfields { get; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="Field"/>, with the given name, type and subfields.
+    /// </summary>
+    /// <param name="name">Name of the field</param>
+    /// <param name="subfields">Sub-fields of the field's type</param>
+    public Field(string name, IEnumerable<Field> subfields) {
+      Name = name;
+      Subfields = subfields.ToList();
+    }
+  }
+}

--- a/src/YouTrackSharp/Internal/FieldSyntaxEncoder.cs
+++ b/src/YouTrackSharp/Internal/FieldSyntaxEncoder.cs
@@ -5,224 +5,252 @@ using System.Reflection;
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Internal {
-  /// <summary>
-  /// Used to convert a given <see cref="Type"/> to the Youtrack REST API's 'fields' syntax, described at the following
-  /// location: <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
-  /// https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html
-  /// </a>.
-  /// </summary>
-  public class FieldSyntaxEncoder {
+namespace YouTrackSharp.Internal
+{
     /// <summary>
-    /// Cached used to store types that were already resolved.
-    /// </summary>
-    /// <remarks>
-    /// The result of the field query can vary depending on the verbose option and the max nesting level.
-    /// Therefore, the key used is a combination of the <see cref="Type"/>, verbosity and max depth.
-    /// </remarks>
-    private Dictionary<Tuple<Type, bool, int>, string> Cache { get; }
-
-    /// <summary>
-    /// Creates an instance of <see cref="FieldSyntaxEncoder"/>
-    /// </summary>
-    public FieldSyntaxEncoder() {
-      Cache = new Dictionary<Tuple<Type, bool, int>, string>();
-    }
-
-    /// <summary>
-    /// Encodes the given <see cref="Type"/>'s members to the Youtrack REST API's 'fields'-syntax, described at
-    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
+    /// Used to convert a given <see cref="Type"/> to the Youtrack REST API's 'fields' syntax, described at the following
+    /// location: <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
     /// https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html
-    /// </a>.<br/>
-    /// This method uses reflexion to retrieve and encodes all public writable properties, decorated with a
-    /// <see cref="JsonPropertyAttribute"/>.<br/>
-    /// It also concatenates the fields retrieved from known subclasses of the given type (defined by the
-    /// <see cref="KnownTypeAttribute"/>).<br/>
-    /// Because the base class and the different subclasses may have fields with similar names (but different types and
-    /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
-    /// have a field with the same name, but each with different types and so, different sub-fields, the two fields will
-    /// be factored into one containing the union of their respective sub-fields.<br/>
-    /// For example:<br/>
-    /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
-    /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
-    /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
-    /// A(B,C,D,E,F). Note that D appears only once.
+    /// </a>.
     /// </summary>
-    /// <param name="type">Type to encode</param>
-    /// <param name="verbose">
-    /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
-    /// with the <see cref="JsonPropertyAttribute"/>.
-    /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
-    /// <see cref="VerboseAttribute"/>.
-    /// </param>
-    /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
-    /// <returns>Fields of the given type, encoded to Youtrack
-    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
-    /// </a>
-    /// </returns>
-    /// <remarks>
-    /// This method does not work well with types that have (direct or indirect) reference loops.
-    /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
-    /// type A. This would result in a stack-overflow.
-    /// </remarks>
-    public string Encode(Type type, bool verbose = true, int maxDepth = Int32.MaxValue) {
-      type = GetLeafType(type);
-      
-      Tuple<Type, bool, int> key = new Tuple<Type, bool, int>(type, verbose, maxDepth);
+    public class FieldSyntaxEncoder
+    {
+        /// <summary>
+        /// Cached used to store types that were already resolved.
+        /// </summary>
+        /// <remarks>
+        /// The result of the field query can vary depending on the verbose option and the max nesting level.
+        /// Therefore, the key used is a combination of the <see cref="Type"/>, verbosity and max depth.
+        /// </remarks>
+        private Dictionary<Tuple<Type, bool, int>, string> Cache { get; }
 
-      if (Cache.ContainsKey(key)) return Cache[key];
+        /// <summary>
+        /// Creates an instance of <see cref="FieldSyntaxEncoder"/>
+        /// </summary>
+        public FieldSyntaxEncoder()
+        {
+            Cache = new Dictionary<Tuple<Type, bool, int>, string>();
+        }
 
-      IEnumerable<Field> fields = GetFields(type, verbose, maxDepth, 0);
-      
-      Cache[key] = string.Join(",", fields.Select(ToString));
+        /// <summary>
+        /// Encodes the given <see cref="Type"/>'s members to the Youtrack REST API's 'fields'-syntax, described at
+        /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
+        /// https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html
+        /// </a>.<br/>
+        /// This method uses reflexion to retrieve and encodes all public writable properties, decorated with a
+        /// <see cref="JsonPropertyAttribute"/>.<br/>
+        /// It also concatenates the fields retrieved from known subclasses of the given type (defined by the
+        /// <see cref="KnownTypeAttribute"/>).<br/>
+        /// Because the base class and the different subclasses may have fields with similar names (but different types and
+        /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
+        /// have a field with the same name, but each with different types and so, different sub-fields, the two fields will
+        /// be factored into one containing the union of their respective sub-fields.<br/>
+        /// For example:<br/>
+        /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
+        /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
+        /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+        /// A(B,C,D,E,F). Note that D appears only once.
+        /// </summary>
+        /// <param name="type">Type to encode</param>
+        /// <param name="verbose">
+        /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
+        /// with the <see cref="JsonPropertyAttribute"/>.
+        /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
+        /// <see cref="VerboseAttribute"/>.
+        /// </param>
+        /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
+        /// <returns>Fields of the given type, encoded to Youtrack
+        /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
+        /// </a>
+        /// </returns>
+        /// <remarks>
+        /// This method does not work well with types that have (direct or indirect) reference loops.
+        /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
+        /// type A. This would result in a stack-overflow.
+        /// </remarks>
+        public string Encode(Type type, bool verbose = true, int maxDepth = Int32.MaxValue)
+        {
+            type = GetLeafType(type);
 
-      return Cache[key];
+            Tuple<Type, bool, int> key = new Tuple<Type, bool, int>(type, verbose, maxDepth);
+
+            if (Cache.ContainsKey(key))
+            {
+                return Cache[key];
+            }
+
+            IEnumerable<Field> fields = GetFields(type, verbose, maxDepth, 0);
+
+            Cache[key] = string.Join(",", fields.Select(ToString));
+
+            return Cache[key];
+        }
+
+        /// <summary>
+        /// Converts the <see cref="Field"/> recursive structure into a string representation, following Youtrack REST API's
+        /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">'field' syntax</a>
+        /// Example: lines(fromPoint(x,y),toPoint(x,y)),color
+        /// </summary>
+        /// <param name="field"><see cref="Field"/> to convert</param>
+        /// <returns></returns>
+        private string ToString(Field field)
+        {
+            if (!field.Subfields.Any())
+            {
+                return field.Name;
+            }
+
+            string subfields = string.Join(",", field.Subfields.Select(ToString));
+
+            return $"{field.Name}({subfields})";
+        }
+
+        /// <summary>
+        /// Recursive method which builds the <see cref="Field"/> structure for the given <see cref="Type"/>'s properties. 
+        /// This method uses reflexion to convert all the public writable properties of teh given <see cref="Type"/>,
+        /// decorated with a <see cref="JsonPropertyAttribute"/> to a <see cref="Field"/><br/>.
+        /// It also retrieves the fields from known subclasses of the given type (defined by the
+        /// <see cref="KnownTypeAttribute"/>).<br/>
+        /// Because the base class and the different subclasses may have fields with similar names (but different types and
+        /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
+        /// have a field with the same name, but different type, each with different sub-fields, the two fields will
+        /// be factored into one containing the union of their respective sub-fields.<br/>
+        /// For example:<br/>
+        /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
+        /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
+        /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+        /// A(B,C,D,E,F). Note that D appears only once.
+        /// </summary>
+        /// <param name="type">Type to convert</param>
+        /// <param name="verbose">
+        /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
+        /// with the <see cref="JsonPropertyAttribute"/>.
+        /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
+        /// <see cref="VerboseAttribute"/>.
+        /// </param>
+        /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
+        /// <param name="level">Current sub-field level (to compare with <see cref="maxDepth"/>)</param>
+        /// <returns>Fields of the given type, encoded to Youtrack
+        /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
+        /// </a>
+        /// </returns>
+        /// <remarks>
+        /// This method does not work well with types that have (direct or indirect) reference loops.
+        /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
+        /// type A. This would result in a stack-overflow.
+        /// </remarks>
+        private IEnumerable<Field> GetFields(Type type, bool verbose, int maxDepth, int level)
+        {
+            if (level == maxDepth)
+            {
+                return Enumerable.Empty<Field>();
+            }
+
+            List<Field> fields = new List<Field>();
+
+            IEnumerable<PropertyInfo> properties = GetProperties(type, verbose);
+            foreach (PropertyInfo propertyInfo in properties)
+            {
+                Type propertyType = GetLeafType(propertyInfo.PropertyType);
+                string propertyName = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName;
+
+                IEnumerable<Field> subfields = GetFields(propertyType, verbose, maxDepth, level + 1);
+
+                fields.Add(new Field(propertyName, subfields));
+            }
+
+            return Merge(fields);
+        }
+
+        /// <summary>
+        /// Merges the given fields into a factored representation, where fields with the same name are combined into one.
+        /// For example, if there are two fields named "A"<br/>
+        /// - The first with subfields B, C and D, ie. A(B,C,D)<br/>
+        /// - The second with subfields D,E and F, ie. A(D,E,F)<br/>
+        /// These two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+        /// A(B,C,D,E,F). Note that D appears only once. 
+        /// </summary>
+        /// <param name="fields"><see cref="Field"/>s to factor</param>
+        /// <returns>Factored fields</returns>
+        private IEnumerable<Field> Merge(IEnumerable<Field> fields)
+        {
+            IEnumerable<IGrouping<string, Field>> groups = fields.GroupBy(field => field.Name);
+
+            foreach (IGrouping<string, Field> group in groups)
+            {
+                IEnumerable<Field> subfields = group.SelectMany(f => f.Subfields);
+                subfields = Merge(subfields);
+
+                yield return new Field(group.Key, subfields);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="PropertyInfo"/> of all public, writable properties marked with a
+        /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
+        /// all of its known subclasses (defined by the <see cref="KnownTypeAttribute"/>.
+        /// If <see cref="verbose"/> is set to <c>false</c>, it will exclude the ones marked with a
+        /// <see cref="VerboseAttribute"/>. 
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> from which to retrieve the properties</param>
+        /// <param name="verbose">
+        /// If <c>false</c> the properties marked with <see cref="KnownTypeAttribute"/> will be excluded from the results. 
+        /// </param>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> of all public, writable properties marked with a
+        /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
+        /// all of its known subclasses.
+        /// </returns>
+        private IEnumerable<PropertyInfo> GetProperties(Type type, bool verbose)
+        {
+            PropertyInfo[] properties = type.GetProperties();
+
+            IEnumerable<PropertyInfo> propertyInfos = properties.Where(p => p.CanWrite)
+                                                                .Where(
+                                                                    p =>
+                                                                        p.GetCustomAttribute<JsonPropertyAttribute>() !=
+                                                                        null);
+
+            if (!verbose)
+            {
+                propertyInfos = propertyInfos.Where(p => p.GetCustomAttribute<VerboseAttribute>() == null);
+            }
+
+            IEnumerable<Type> knownSubtypes =
+                type.GetCustomAttributes<KnownTypeAttribute>(false).Select(attr => attr.Type);
+            IEnumerable<PropertyInfo> subtypesProperties =
+                knownSubtypes.SelectMany(subtype => GetProperties(subtype, verbose));
+
+            return propertyInfos.Concat(subtypesProperties);
+        }
+
+        /// <summary>
+        /// Returns the "leaf" type argument of any generic type.<br/>
+        /// <i>Note: Generic types are nested, the "leaf" meaning the non-generic type at the bottom of the nesting chain</i>
+        /// <br/>
+        /// For example, a <see cref="List{T}"/> of <see cref="string"/>, will yield <see cref="string"/>.
+        /// And a <see cref="List{T}"/> of <see cref="List{T}"/> of <see cref="string"/>
+        /// will also yield <see cref="string"/>.<br/>
+        /// <br/>
+        /// For generic types with multiple type parameters, it will always follow the last, which is usually the value type.
+        /// For example, a <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="int"/>,
+        /// will yield <see cref="int"/>.<br/>
+        /// A <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="List{T}"/> of
+        /// <see cref="int"/>, will also yield <see cref="int"/>.
+        /// </summary>
+        /// <param name="type">Input <see cref="Type"/></param>
+        /// <returns>Leaf type if the input type is generic, otherwise itself</returns>
+        /// <remarks>
+        /// The returned type is guaranteed to be non-generic.
+        /// </remarks>
+        private Type GetLeafType(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return type;
+            }
+
+            return GetLeafType(type.GetGenericArguments().Last());
+        }
     }
-
-    /// <summary>
-    /// Converts the <see cref="Field"/> recursive structure into a string representation, following Youtrack REST API's
-    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">'field' syntax</a>
-    /// Example: lines(fromPoint(x,y),toPoint(x,y)),color
-    /// </summary>
-    /// <param name="field"><see cref="Field"/> to convert</param>
-    /// <returns></returns>
-    private string ToString(Field field) {
-      if (!field.Subfields.Any()) return field.Name;
-
-      string subfields = string.Join(",", field.Subfields.Select(ToString));
-
-      return $"{field.Name}({subfields})";
-    }
-
-    /// <summary>
-    /// Recursive method which builds the <see cref="Field"/> structure for the given <see cref="Type"/>'s properties. 
-    /// This method uses reflexion to convert all the public writable properties of teh given <see cref="Type"/>,
-    /// decorated with a <see cref="JsonPropertyAttribute"/> to a <see cref="Field"/><br/>.
-    /// It also retrieves the fields from known subclasses of the given type (defined by the
-    /// <see cref="KnownTypeAttribute"/>).<br/>
-    /// Because the base class and the different subclasses may have fields with similar names (but different types and
-    /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
-    /// have a field with the same name, but different type, each with different sub-fields, the two fields will
-    /// be factored into one containing the union of their respective sub-fields.<br/>
-    /// For example:<br/>
-    /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
-    /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
-    /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
-    /// A(B,C,D,E,F). Note that D appears only once.
-    /// </summary>
-    /// <param name="type">Type to convert</param>
-    /// <param name="verbose">
-    /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
-    /// with the <see cref="JsonPropertyAttribute"/>.
-    /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
-    /// <see cref="VerboseAttribute"/>.
-    /// </param>
-    /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
-    /// <param name="level">Current sub-field level (to compare with <see cref="maxDepth"/>)</param>
-    /// <returns>Fields of the given type, encoded to Youtrack
-    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
-    /// </a>
-    /// </returns>
-    /// <remarks>
-    /// This method does not work well with types that have (direct or indirect) reference loops.
-    /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
-    /// type A. This would result in a stack-overflow.
-    /// </remarks>
-    private IEnumerable<Field> GetFields(Type type, bool verbose, int maxDepth, int level) {
-      if (level == maxDepth) return Enumerable.Empty<Field>();
-
-      List<Field> fields = new List<Field>();
-      
-      IEnumerable<PropertyInfo> properties = GetProperties(type, verbose);
-      foreach (PropertyInfo propertyInfo in properties) {
-        Type propertyType = GetLeafType(propertyInfo.PropertyType);
-        string propertyName = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName;
-        
-        IEnumerable<Field> subfields = GetFields(propertyType, verbose, maxDepth, level + 1);
-
-        fields.Add(new Field(propertyName, subfields));
-      }
-
-      return Merge(fields);
-    }
-
-    /// <summary>
-    /// Merges the given fields into a factored representation, where fields with the same name are combined into one.
-    /// For example, if there are two fields named "A"<br/>
-    /// - The first with subfields B, C and D, ie. A(B,C,D)<br/>
-    /// - The second with subfields D,E and F, ie. A(D,E,F)<br/>
-    /// These two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
-    /// A(B,C,D,E,F). Note that D appears only once. 
-    /// </summary>
-    /// <param name="fields"><see cref="Field"/>s to factor</param>
-    /// <returns>Factored fields</returns>
-    private IEnumerable<Field> Merge(IEnumerable<Field> fields) {
-      IEnumerable<IGrouping<string, Field>> groups = fields.GroupBy(field => field.Name);
-
-      foreach (IGrouping<string, Field> group in groups) {
-        IEnumerable<Field> subfields = group.SelectMany(f => f.Subfields);
-        subfields = Merge(subfields);
-
-        yield return new Field(group.Key, subfields);
-      }
-    }
-
-    /// <summary>
-    /// Retrieves the <see cref="PropertyInfo"/> of all public, writable properties marked with a
-    /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
-    /// all of its known subclasses (defined by the <see cref="KnownTypeAttribute"/>.
-    /// If <see cref="verbose"/> is set to <c>false</c>, it will exclude the ones marked with a
-    /// <see cref="VerboseAttribute"/>. 
-    /// </summary>
-    /// <param name="type"><see cref="Type"/> from which to retrieve the properties</param>
-    /// <param name="verbose">
-    /// If <c>false</c> the properties marked with <see cref="KnownTypeAttribute"/> will be excluded from the results. 
-    /// </param>
-    /// <returns>
-    /// The <see cref="PropertyInfo"/> of all public, writable properties marked with a
-    /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
-    /// all of its known subclasses.
-    /// </returns>
-    private IEnumerable<PropertyInfo> GetProperties(Type type, bool verbose) {
-      PropertyInfo[] properties = type.GetProperties();
-      
-      IEnumerable<PropertyInfo> propertyInfos = properties.Where(p => p.CanWrite)
-                                                          .Where(p => p.GetCustomAttribute<JsonPropertyAttribute>() != null);
-
-      if (!verbose) {
-        propertyInfos = propertyInfos.Where(p => p.GetCustomAttribute<VerboseAttribute>() == null);
-      }
-
-      IEnumerable<Type> knownSubtypes = type.GetCustomAttributes<KnownTypeAttribute>(false).Select(attr => attr.Type);
-      IEnumerable<PropertyInfo> subtypesProperties =
-        knownSubtypes.SelectMany(subtype => GetProperties(subtype, verbose));
-
-      return propertyInfos.Concat(subtypesProperties);
-    }
-
-    /// <summary>
-    /// Returns the "leaf" type argument of any generic type.<br/>
-    /// <i>Note: Generic types are nested, the "leaf" meaning the non-generic type at the bottom of the nesting chain</i>
-    /// <br/>
-    /// For example, a <see cref="List{T}"/> of <see cref="string"/>, will yield <see cref="string"/>.
-    /// And a <see cref="List{T}"/> of <see cref="List{T}"/> of <see cref="string"/>
-    /// will also yield <see cref="string"/>.<br/>
-    /// <br/>
-    /// For generic types with multiple type parameters, it will always follow the last, which is usually the value type.
-    /// For example, a <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="int"/>,
-    /// will yield <see cref="int"/>.<br/>
-    /// A <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="List{T}"/> of
-    /// <see cref="int"/>, will also yield <see cref="int"/>.
-    /// </summary>
-    /// <param name="type">Input <see cref="Type"/></param>
-    /// <returns>Leaf type if the input type is generic, otherwise itself</returns>
-    /// <remarks>
-    /// The returned type is guaranteed to be non-generic.
-    /// </remarks>
-    private Type GetLeafType(Type type) {
-      if (!type.IsGenericType) return type;
-
-      return GetLeafType(type.GetGenericArguments().Last());
-    }
-  }
 }

--- a/src/YouTrackSharp/Internal/FieldSyntaxEncoder.cs
+++ b/src/YouTrackSharp/Internal/FieldSyntaxEncoder.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
+
+namespace YouTrackSharp.Internal {
+  /// <summary>
+  /// Used to convert a given <see cref="Type"/> to the Youtrack REST API's 'fields' syntax, described at the following
+  /// location: <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
+  /// https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html
+  /// </a>.
+  /// </summary>
+  public class FieldSyntaxEncoder {
+    /// <summary>
+    /// Cached used to store types that were already resolved.
+    /// </summary>
+    /// <remarks>
+    /// The result of the field query can vary depending on the verbose option and the max nesting level.
+    /// Therefore, the key used is a combination of the <see cref="Type"/>, verbosity and max depth.
+    /// </remarks>
+    private Dictionary<Tuple<Type, bool, int>, string> Cache { get; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="FieldSyntaxEncoder"/>
+    /// </summary>
+    public FieldSyntaxEncoder() {
+      Cache = new Dictionary<Tuple<Type, bool, int>, string>();
+    }
+
+    /// <summary>
+    /// Encodes the given <see cref="Type"/>'s members to the Youtrack REST API's 'fields'-syntax, described at
+    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">
+    /// https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html
+    /// </a>.<br/>
+    /// This method uses reflexion to retrieve and encodes all public writable properties, decorated with a
+    /// <see cref="JsonPropertyAttribute"/>.<br/>
+    /// It also concatenates the fields retrieved from known subclasses of the given type (defined by the
+    /// <see cref="KnownTypeAttribute"/>).<br/>
+    /// Because the base class and the different subclasses may have fields with similar names (but different types and
+    /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
+    /// have a field with the same name, but each with different types and so, different sub-fields, the two fields will
+    /// be factored into one containing the union of their respective sub-fields.<br/>
+    /// For example:<br/>
+    /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
+    /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
+    /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+    /// A(B,C,D,E,F). Note that D appears only once.
+    /// </summary>
+    /// <param name="type">Type to encode</param>
+    /// <param name="verbose">
+    /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
+    /// with the <see cref="JsonPropertyAttribute"/>.
+    /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
+    /// <see cref="VerboseAttribute"/>.
+    /// </param>
+    /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
+    /// <returns>Fields of the given type, encoded to Youtrack
+    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
+    /// </a>
+    /// </returns>
+    /// <remarks>
+    /// This method does not work well with types that have (direct or indirect) reference loops.
+    /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
+    /// type A. This would result in a stack-overflow.
+    /// </remarks>
+    public string Encode(Type type, bool verbose = true, int maxDepth = Int32.MaxValue) {
+      type = GetLeafType(type);
+      
+      Tuple<Type, bool, int> key = new Tuple<Type, bool, int>(type, verbose, maxDepth);
+
+      if (Cache.ContainsKey(key)) return Cache[key];
+
+      IEnumerable<Field> fields = GetFields(type, verbose, maxDepth, 0);
+      
+      Cache[key] = string.Join(",", fields.Select(ToString));
+
+      return Cache[key];
+    }
+
+    /// <summary>
+    /// Converts the <see cref="Field"/> recursive structure into a string representation, following Youtrack REST API's
+    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">'field' syntax</a>
+    /// Example: lines(fromPoint(x,y),toPoint(x,y)),color
+    /// </summary>
+    /// <param name="field"><see cref="Field"/> to convert</param>
+    /// <returns></returns>
+    private string ToString(Field field) {
+      if (!field.Subfields.Any()) return field.Name;
+
+      string subfields = string.Join(",", field.Subfields.Select(ToString));
+
+      return $"{field.Name}({subfields})";
+    }
+
+    /// <summary>
+    /// Recursive method which builds the <see cref="Field"/> structure for the given <see cref="Type"/>'s properties. 
+    /// This method uses reflexion to convert all the public writable properties of teh given <see cref="Type"/>,
+    /// decorated with a <see cref="JsonPropertyAttribute"/> to a <see cref="Field"/><br/>.
+    /// It also retrieves the fields from known subclasses of the given type (defined by the
+    /// <see cref="KnownTypeAttribute"/>).<br/>
+    /// Because the base class and the different subclasses may have fields with similar names (but different types and
+    /// sub-fields), all the fields discovered this way are "factored" together. Therefore, if two known subclasses both
+    /// have a field with the same name, but different type, each with different sub-fields, the two fields will
+    /// be factored into one containing the union of their respective sub-fields.<br/>
+    /// For example:<br/>
+    /// - The first subclass has a field named A with subfields B, C and D, ie. A(B,C,D)<br/>
+    /// - The second subclass also has a field A but with subfields D,E and F, ie. A(D,E,F)<br/>
+    /// In that case, these two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+    /// A(B,C,D,E,F). Note that D appears only once.
+    /// </summary>
+    /// <param name="type">Type to convert</param>
+    /// <param name="verbose">
+    /// Verbosity. If <c>true</c>, will include all public writable properties of the given <see cref="Type"/>, marked
+    /// with the <see cref="JsonPropertyAttribute"/>.
+    /// But if <c>false</c>, it will exclude from these all the ones that were marked with the
+    /// <see cref="VerboseAttribute"/>.
+    /// </param>
+    /// <param name="maxDepth">Max sub-field depth to go from the given type.</param>
+    /// <param name="level">Current sub-field level (to compare with <see cref="maxDepth"/>)</param>
+    /// <returns>Fields of the given type, encoded to Youtrack
+    /// <a href="https://www.jetbrains.com/help/youtrack/standalone/api-fields-syntax.html">REST API's 'field' syntax
+    /// </a>
+    /// </returns>
+    /// <remarks>
+    /// This method does not work well with types that have (direct or indirect) reference loops.
+    /// For example, a class A that contains two fields of type B and C, where the type B itself contains a field of
+    /// type A. This would result in a stack-overflow.
+    /// </remarks>
+    private IEnumerable<Field> GetFields(Type type, bool verbose, int maxDepth, int level) {
+      if (level == maxDepth) return Enumerable.Empty<Field>();
+
+      List<Field> fields = new List<Field>();
+      
+      IEnumerable<PropertyInfo> properties = GetProperties(type, verbose);
+      foreach (PropertyInfo propertyInfo in properties) {
+        Type propertyType = GetLeafType(propertyInfo.PropertyType);
+        string propertyName = propertyInfo.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName;
+        
+        IEnumerable<Field> subfields = GetFields(propertyType, verbose, maxDepth, level + 1);
+
+        fields.Add(new Field(propertyName, subfields));
+      }
+
+      return Merge(fields);
+    }
+
+    /// <summary>
+    /// Merges the given fields into a factored representation, where fields with the same name are combined into one.
+    /// For example, if there are two fields named "A"<br/>
+    /// - The first with subfields B, C and D, ie. A(B,C,D)<br/>
+    /// - The second with subfields D,E and F, ie. A(D,E,F)<br/>
+    /// These two fields will be combined into one, with name A and subfields B, C, D, E and F, ie.
+    /// A(B,C,D,E,F). Note that D appears only once. 
+    /// </summary>
+    /// <param name="fields"><see cref="Field"/>s to factor</param>
+    /// <returns>Factored fields</returns>
+    private IEnumerable<Field> Merge(IEnumerable<Field> fields) {
+      IEnumerable<IGrouping<string, Field>> groups = fields.GroupBy(field => field.Name);
+
+      foreach (IGrouping<string, Field> group in groups) {
+        IEnumerable<Field> subfields = group.SelectMany(f => f.Subfields);
+        subfields = Merge(subfields);
+
+        yield return new Field(group.Key, subfields);
+      }
+    }
+
+    /// <summary>
+    /// Retrieves the <see cref="PropertyInfo"/> of all public, writable properties marked with a
+    /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
+    /// all of its known subclasses (defined by the <see cref="KnownTypeAttribute"/>.
+    /// If <see cref="verbose"/> is set to <c>false</c>, it will exclude the ones marked with a
+    /// <see cref="VerboseAttribute"/>. 
+    /// </summary>
+    /// <param name="type"><see cref="Type"/> from which to retrieve the properties</param>
+    /// <param name="verbose">
+    /// If <c>false</c> the properties marked with <see cref="KnownTypeAttribute"/> will be excluded from the results. 
+    /// </param>
+    /// <returns>
+    /// The <see cref="PropertyInfo"/> of all public, writable properties marked with a
+    /// <see cref="JsonPropertyAttribute"/> of the given <see cref="Type"/> and
+    /// all of its known subclasses.
+    /// </returns>
+    private IEnumerable<PropertyInfo> GetProperties(Type type, bool verbose) {
+      PropertyInfo[] properties = type.GetProperties();
+      
+      IEnumerable<PropertyInfo> propertyInfos = properties.Where(p => p.CanWrite)
+                                                          .Where(p => p.GetCustomAttribute<JsonPropertyAttribute>() != null);
+
+      if (!verbose) {
+        propertyInfos = propertyInfos.Where(p => p.GetCustomAttribute<VerboseAttribute>() == null);
+      }
+
+      IEnumerable<Type> knownSubtypes = type.GetCustomAttributes<KnownTypeAttribute>(false).Select(attr => attr.Type);
+      IEnumerable<PropertyInfo> subtypesProperties =
+        knownSubtypes.SelectMany(subtype => GetProperties(subtype, verbose));
+
+      return propertyInfos.Concat(subtypesProperties);
+    }
+
+    /// <summary>
+    /// Returns the "leaf" type argument of any generic type.<br/>
+    /// <i>Note: Generic types are nested, the "leaf" meaning the non-generic type at the bottom of the nesting chain</i>
+    /// <br/>
+    /// For example, a <see cref="List{T}"/> of <see cref="string"/>, will yield <see cref="string"/>.
+    /// And a <see cref="List{T}"/> of <see cref="List{T}"/> of <see cref="string"/>
+    /// will also yield <see cref="string"/>.<br/>
+    /// <br/>
+    /// For generic types with multiple type parameters, it will always follow the last, which is usually the value type.
+    /// For example, a <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="int"/>,
+    /// will yield <see cref="int"/>.<br/>
+    /// A <see cref="Dictionary{TKey,TValue}"/> of key <see cref="string"/> and value <see cref="List{T}"/> of
+    /// <see cref="int"/>, will also yield <see cref="int"/>.
+    /// </summary>
+    /// <param name="type">Input <see cref="Type"/></param>
+    /// <returns>Leaf type if the input type is generic, otherwise itself</returns>
+    /// <remarks>
+    /// The returned type is guaranteed to be non-generic.
+    /// </remarks>
+    private Type GetLeafType(Type type) {
+      if (!type.IsGenericType) return type;
+
+      return GetLeafType(type.GetGenericArguments().Last());
+    }
+  }
+}

--- a/src/YouTrackSharp/Json/KnownTypeConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeConverter.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using YouTrackSharp.SerializationAttributes;
+
+namespace YouTrackSharp.Json {
+  /// <summary>
+  /// This <see cref="JsonConverter"/> allows to convert a JSON string into a concrete object that extends a given base
+  /// type.<br/>
+  /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
+  /// the base class, and which lists the possible sub-types of that class.<br/><br/>
+  /// Among these, the concrete sub-type instantiated is inferred from the Json object's "$type" field, which is
+  /// compared to the defined known types (ignoring their namespace).<br/>
+  /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
+  /// found, the base class is instantiated instead.  
+  /// </summary>
+  /// <typeparam name="T">Base type</typeparam>
+  public class KnownTypeConverter<T> : JsonConverter<T> where T:new() {
+    private readonly TypedJObjectConverter<T> _objectConverter;
+
+    public KnownTypeConverter() {
+      _objectConverter = new TypedJObjectConverter<T>();
+    }
+    
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, T value, JsonSerializer serializer) {
+      throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Reads the JSON representation of the object.<br/>
+    /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
+    /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
+    /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
+    /// deserialized to an instance of the base class directly. 
+    /// </summary>
+    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+    /// <param name="objectType">Type of the object.</param>
+    /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+    /// <param name="hasExistingValue">The existing value has a value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    /// <returns>The object value.</returns>
+    public override T ReadJson(JsonReader reader, Type objectType, T existingValue, bool hasExistingValue, JsonSerializer serializer) {
+      List<Type> types = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+
+      JObject obj = JObject.Load(reader);
+
+      return _objectConverter.ReadObject(obj, types, serializer);
+    }
+    
+    /// <inheritdoc />
+    public override bool CanRead => true;
+    
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+  }
+}

--- a/src/YouTrackSharp/Json/KnownTypeConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeConverter.cs
@@ -6,57 +6,66 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Json {
-  /// <summary>
-  /// This <see cref="JsonConverter"/> allows to convert a JSON string into a concrete object that extends a given base
-  /// type.<br/>
-  /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
-  /// the base class, and which lists the possible sub-types of that class.<br/><br/>
-  /// Among these, the concrete sub-type instantiated is inferred from the Json object's "$type" field, which is
-  /// compared to the defined known types (ignoring their namespace).<br/>
-  /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
-  /// found, the base class is instantiated instead.  
-  /// </summary>
-  /// <typeparam name="T">Base type</typeparam>
-  public class KnownTypeConverter<T> : JsonConverter<T> where T:new() {
-    private readonly TypedJObjectConverter<T> _objectConverter;
-
-    public KnownTypeConverter() {
-      _objectConverter = new TypedJObjectConverter<T>();
-    }
-    
-    /// <inheritdoc />
-    public override void WriteJson(JsonWriter writer, T value, JsonSerializer serializer) {
-      throw new NotImplementedException();
-    }
-
+namespace YouTrackSharp.Json
+{
     /// <summary>
-    /// Reads the JSON representation of the object.<br/>
-    /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
-    /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
-    /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
-    /// deserialized to an instance of the base class directly. 
+    /// This <see cref="JsonConverter"/> allows to convert a JSON string into a concrete object that extends a given base
+    /// type.<br/>
+    /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
+    /// the base class, and which lists the possible sub-types of that class.<br/><br/>
+    /// Among these, the concrete sub-type instantiated is inferred from the Json object's "$type" field, which is
+    /// compared to the defined known types (ignoring their namespace).<br/>
+    /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
+    /// found, the base class is instantiated instead.  
     /// </summary>
-    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
-    /// <param name="objectType">Type of the object.</param>
-    /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
-    /// <param name="hasExistingValue">The existing value has a value.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    /// <returns>The object value.</returns>
-    public override T ReadJson(JsonReader reader, Type objectType, T existingValue, bool hasExistingValue, JsonSerializer serializer) {
-      if (reader.TokenType == JsonToken.Null) return default;
-      
-      List<Type> types = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+    /// <typeparam name="T">Base type</typeparam>
+    public class KnownTypeConverter<T> : JsonConverter<T> where T : new()
+    {
+        private readonly TypedJObjectConverter<T> _objectConverter;
 
-      JObject obj = JObject.Load(reader);
+        /// <inheritdoc />
+        public override bool CanRead => true;
 
-      return _objectConverter.ReadObject(obj, types, serializer);
+        /// <inheritdoc />
+        public override bool CanWrite => false;
+
+        public KnownTypeConverter()
+        {
+            _objectConverter = new TypedJObjectConverter<T>();
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, T value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.<br/>
+        /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
+        /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
+        /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
+        /// deserialized to an instance of the base class directly. 
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override T ReadJson(JsonReader reader, Type objectType, T existingValue, bool hasExistingValue,
+                                   JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return default;
+            }
+
+            List<Type> types = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+
+            JObject obj = JObject.Load(reader);
+
+            return _objectConverter.ReadObject(obj, types, serializer);
+        }
     }
-    
-    /// <inheritdoc />
-    public override bool CanRead => true;
-    
-    /// <inheritdoc />
-    public override bool CanWrite => false;
-  }
 }

--- a/src/YouTrackSharp/Json/KnownTypeConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeConverter.cs
@@ -44,6 +44,8 @@ namespace YouTrackSharp.Json {
     /// <param name="serializer">The calling serializer.</param>
     /// <returns>The object value.</returns>
     public override T ReadJson(JsonReader reader, Type objectType, T existingValue, bool hasExistingValue, JsonSerializer serializer) {
+      if (reader.TokenType == JsonToken.Null) return default;
+      
       List<Type> types = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
 
       JObject obj = JObject.Load(reader);

--- a/src/YouTrackSharp/Json/KnownTypeListConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeListConverter.cs
@@ -43,6 +43,8 @@ namespace YouTrackSharp.Json {
     /// <param name="serializer">The calling serializer.</param>
     /// <returns>The object value.</returns>
     public override List<T> ReadJson(JsonReader reader, Type objectType, List<T> existingValue, bool hasExistingValue, JsonSerializer serializer) {
+      if (reader.TokenType == JsonToken.Null) return null;
+      
       List<Type> knownTypes = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
 
       JArray array = JArray.Load(reader);

--- a/src/YouTrackSharp/Json/KnownTypeListConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeListConverter.cs
@@ -6,56 +6,67 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Json {
-  /// <summary>
-  /// This class allows to convert a JSON array into a list of objects, each extending a given base type.<br/>
-  /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
-  /// the base class, and which lists the possible sub-types of that class.<br/><br/>
-  /// Among these, the concrete sub-type instantiated is inferred from each Json object's "$type" field, which is
-  /// compared to the defined known types (ignoring their namespace).<br/>
-  /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
-  /// found, the base class is instantiated instead.
-  /// </summary>
-  /// <typeparam name="T">Base type</typeparam>
-  public class KnownTypeListConverter<T> : JsonConverter<List<T>> where T:new() {
-    private readonly TypedJObjectConverter<T> _objectConverter;
-
-    public KnownTypeListConverter() {
-      _objectConverter = new TypedJObjectConverter<T>();
-    }
-
-    /// <inheritdoc />
-    public override void WriteJson(JsonWriter writer, List<T> value, JsonSerializer serializer) {
-      throw new NotImplementedException();
-    }
-
+namespace YouTrackSharp.Json
+{
     /// <summary>
-    /// Reads the JSON representation of the object.<br/>
-    /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
-    /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
-    /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
-    /// deserialized to an instance of the base class directly. 
+    /// This class allows to convert a JSON array into a list of objects, each extending a given base type.<br/>
+    /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
+    /// the base class, and which lists the possible sub-types of that class.<br/><br/>
+    /// Among these, the concrete sub-type instantiated is inferred from each Json object's "$type" field, which is
+    /// compared to the defined known types (ignoring their namespace).<br/>
+    /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
+    /// found, the base class is instantiated instead.
     /// </summary>
-    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
-    /// <param name="objectType">Type of the object.</param>
-    /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
-    /// <param name="hasExistingValue">The existing value has a value.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    /// <returns>The object value.</returns>
-    public override List<T> ReadJson(JsonReader reader, Type objectType, List<T> existingValue, bool hasExistingValue, JsonSerializer serializer) {
-      if (reader.TokenType == JsonToken.Null) return null;
-      
-      List<Type> knownTypes = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+    /// <typeparam name="T">Base type</typeparam>
+    public class KnownTypeListConverter<T> : JsonConverter<List<T>> where T : new()
+    {
+        private readonly TypedJObjectConverter<T> _objectConverter;
 
-      JArray array = JArray.Load(reader);
+        /// <inheritdoc />
+        public override bool CanRead => true;
 
-      return array.Select(token => _objectConverter.ReadObject(token as JObject, knownTypes, serializer)).ToList();
+        /// <inheritdoc />
+        public override bool CanWrite => false;
+
+        public KnownTypeListConverter()
+        {
+            _objectConverter = new TypedJObjectConverter<T>();
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, List<T> value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.<br/>
+        /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
+        /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
+        /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
+        /// deserialized to an instance of the base class directly. 
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override List<T> ReadJson(JsonReader reader, Type objectType, List<T> existingValue,
+                                         bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            List<Type> knownTypes =
+                typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+
+            JArray array = JArray.Load(reader);
+
+            return array.Select(token => _objectConverter.ReadObject(token as JObject, knownTypes, serializer))
+                        .ToList();
+        }
     }
-
-    /// <inheritdoc />
-    public override bool CanRead => true;
-    
-    /// <inheritdoc />
-    public override bool CanWrite => false;
-  }
 }

--- a/src/YouTrackSharp/Json/KnownTypeListConverter.cs
+++ b/src/YouTrackSharp/Json/KnownTypeListConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using YouTrackSharp.SerializationAttributes;
+
+namespace YouTrackSharp.Json {
+  /// <summary>
+  /// This class allows to convert a JSON array into a list of objects, each extending a given base type.<br/>
+  /// This is used in conjunction with the <see cref="KnownTypeAttribute"/>, defined on
+  /// the base class, and which lists the possible sub-types of that class.<br/><br/>
+  /// Among these, the concrete sub-type instantiated is inferred from each Json object's "$type" field, which is
+  /// compared to the defined known types (ignoring their namespace).<br/>
+  /// If the "$type" field is undefined, or no <see cref="KnownTypeAttribute"/> matching the "$type" parameter is
+  /// found, the base class is instantiated instead.
+  /// </summary>
+  /// <typeparam name="T">Base type</typeparam>
+  public class KnownTypeListConverter<T> : JsonConverter<List<T>> where T:new() {
+    private readonly TypedJObjectConverter<T> _objectConverter;
+
+    public KnownTypeListConverter() {
+      _objectConverter = new TypedJObjectConverter<T>();
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, List<T> value, JsonSerializer serializer) {
+      throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Reads the JSON representation of the object.<br/>
+    /// This method will instanciate a subclass of the given <see cref="objectType"/>, based on the "$type" parameter
+    /// of the json string, which is compared to <see cref="KnownTypeAttribute"/> defined for that base class.<br/>
+    /// If the "$type" parameter is not defined, or no matching <see cref="KnownTypeAttribute"/> is found, the json is
+    /// deserialized to an instance of the base class directly. 
+    /// </summary>
+    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+    /// <param name="objectType">Type of the object.</param>
+    /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>
+    /// <param name="hasExistingValue">The existing value has a value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    /// <returns>The object value.</returns>
+    public override List<T> ReadJson(JsonReader reader, Type objectType, List<T> existingValue, bool hasExistingValue, JsonSerializer serializer) {
+      List<Type> knownTypes = typeof(T).GetCustomAttributes<KnownTypeAttribute>().Select(attr => attr.Type).ToList();
+
+      JArray array = JArray.Load(reader);
+
+      return array.Select(token => _objectConverter.ReadObject(token as JObject, knownTypes, serializer)).ToList();
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+    
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+  }
+}

--- a/src/YouTrackSharp/Json/TypedJObjectConverter.cs
+++ b/src/YouTrackSharp/Json/TypedJObjectConverter.cs
@@ -4,23 +4,31 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace YouTrackSharp.Json {
-  public class TypedJObjectConverter<T> {
-    public T ReadObject(JObject token, List<Type> knownTypes, JsonSerializer serializer) {
-      if (token == null) throw new ArgumentException("Invalid token");
+namespace YouTrackSharp.Json
+{
+    public class TypedJObjectConverter<T>
+    {
+        public T ReadObject(JObject token, List<Type> knownTypes, JsonSerializer serializer)
+        {
+            if (token == null)
+            {
+                throw new ArgumentException("Invalid token");
+            }
 
-      string jsonType = token["$type"]?.ToString();
-      if (jsonType == null) {
-        return token.ToObject<T>(serializer);
-      }
+            string jsonType = token["$type"]?.ToString();
+            if (jsonType == null)
+            {
+                return token.ToObject<T>(serializer);
+            }
 
-      Type type = knownTypes.FirstOrDefault(t => t.Name.EndsWith(jsonType));
+            Type type = knownTypes.FirstOrDefault(t => t.Name.EndsWith(jsonType));
 
-      if (type == null) {
-        return token.ToObject<T>(serializer);
-      }
+            if (type == null)
+            {
+                return token.ToObject<T>(serializer);
+            }
 
-      return (T)token.ToObject(type, serializer);
+            return (T)token.ToObject(type, serializer);
+        }
     }
-  }
 }

--- a/src/YouTrackSharp/Json/TypedJObjectConverter.cs
+++ b/src/YouTrackSharp/Json/TypedJObjectConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace YouTrackSharp.Json {
+  public class TypedJObjectConverter<T> {
+    public T ReadObject(JObject token, List<Type> knownTypes, JsonSerializer serializer) {
+      if (token == null) throw new ArgumentException("Invalid token");
+
+      string jsonType = token["$type"]?.ToString();
+      if (jsonType == null) {
+        return token.ToObject<T>(serializer);
+      }
+
+      Type type = knownTypes.FirstOrDefault(t => t.Name.EndsWith(jsonType));
+
+      if (type == null) {
+        return token.ToObject<T>(serializer);
+      }
+
+      return (T)token.ToObject(type, serializer);
+    }
+  }
+}

--- a/src/YouTrackSharp/SerializationAttributes/KnownTypeAttribute.cs
+++ b/src/YouTrackSharp/SerializationAttributes/KnownTypeAttribute.cs
@@ -1,24 +1,27 @@
 using System;
 
-namespace YouTrackSharp.SerializationAttributes {
-  /// <summary>
-  /// Attribute used to decorate a parent class with its known subtypes.<br/>
-  /// This is used to identify candidate subclasses when generating REST requests (to include the subclasses'
-  /// properties).
-  /// </summary>
-  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-  public class KnownTypeAttribute : Attribute {
+namespace YouTrackSharp.SerializationAttributes
+{
     /// <summary>
-    /// Known subclass's type
+    /// Attribute used to decorate a parent class with its known subtypes.<br/>
+    /// This is used to identify candidate subclasses when generating REST requests (to include the subclasses'
+    /// properties).
     /// </summary>
-    public Type Type { get; }
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class KnownTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Known subclass's type
+        /// </summary>
+        public Type Type { get; }
 
-    /// <summary>
-    /// Creates an instance of the <see cref="KnownTypeAttribute"/>, with the given subclass' type.
-    /// </summary>
-    /// <param name="type"></param>
-    public KnownTypeAttribute(Type type) {
-      Type = type;
+        /// <summary>
+        /// Creates an instance of the <see cref="KnownTypeAttribute"/>, with the given subclass' type.
+        /// </summary>
+        /// <param name="type"></param>
+        public KnownTypeAttribute(Type type)
+        {
+            Type = type;
+        }
     }
-  }
 }

--- a/src/YouTrackSharp/SerializationAttributes/KnownTypeAttribute.cs
+++ b/src/YouTrackSharp/SerializationAttributes/KnownTypeAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace YouTrackSharp.SerializationAttributes {
+  /// <summary>
+  /// Attribute used to decorate a parent class with its known subtypes.<br/>
+  /// This is used to identify candidate subclasses when generating REST requests (to include the subclasses'
+  /// properties).
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+  public class KnownTypeAttribute : Attribute {
+    /// <summary>
+    /// Known subclass's type
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="KnownTypeAttribute"/>, with the given subclass' type.
+    /// </summary>
+    /// <param name="type"></param>
+    public KnownTypeAttribute(Type type) {
+      Type = type;
+    }
+  }
+}

--- a/src/YouTrackSharp/SerializationAttributes/VerboseAttribute.cs
+++ b/src/YouTrackSharp/SerializationAttributes/VerboseAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace YouTrackSharp.SerializationAttributes {
+  /// <summary>
+  /// This attribute is used to mark a property as being only retrieved when verbose information was requested. 
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Property)]
+  public class VerboseAttribute : Attribute { }
+}

--- a/src/YouTrackSharp/SerializationAttributes/VerboseAttribute.cs
+++ b/src/YouTrackSharp/SerializationAttributes/VerboseAttribute.cs
@@ -1,9 +1,11 @@
 using System;
 
-namespace YouTrackSharp.SerializationAttributes {
-  /// <summary>
-  /// This attribute is used to mark a property as being only retrieved when verbose information was requested. 
-  /// </summary>
-  [AttributeUsage(AttributeTargets.Property)]
-  public class VerboseAttribute : Attribute { }
+namespace YouTrackSharp.SerializationAttributes
+{
+    /// <summary>
+    /// This attribute is used to mark a property as being only retrieved when verbose information was requested. 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class VerboseAttribute : Attribute
+    { }
 }

--- a/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YouTrackSharp.Tests.Infrastructure {
+  /// <summary>
+  /// Connection mock used to return predefined HTTP responses, for testing purposes.
+  /// </summary>
+  public class ConnectionStub : Connection {
+    private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
+
+    private TimeSpan TimeOut => TimeSpan.FromSeconds(100);
+
+    /// <summary>
+    /// Creates an instance of <see cref="ConnectionStub"/> with give response delegate
+    /// </summary>
+    /// <param name="executeRequest">Request delegate</param>
+    public ConnectionStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) : base("http://fake.connection.com/") {
+      ExecuteRequest = executeRequest;
+    }
+    
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> configured to return a predefined message and HTTP status
+    /// on request.
+    /// </summary>
+    /// <returns><see cref="HttpClient"/> configured to return a predefined message and HTTP status</returns>
+    public override Task<HttpClient> GetAuthenticatedHttpClient() {
+      return Task.FromResult(CreateClient());
+    }
+
+    private HttpClient CreateClient() {
+      HttpClient httpClient = new HttpClient(new HttpClientHandlerStub(ExecuteRequest));
+      httpClient.BaseAddress = ServerUri;
+      httpClient.Timeout = TimeOut;
+
+      return httpClient;
+    }
+  }
+
+  /// <summary>
+  /// <see cref="HttpClientHandler"/> mock, that returns a predefined reply and HTTP status code. 
+  /// </summary>
+  public class HttpClientHandlerStub : HttpClientHandler {
+    private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
+    
+    /// <summary>
+    /// Creates an <see cref="HttpClientHandlerStub"/> instance that delegates HttpRequestMessages
+    /// </summary>
+    /// <param name="executeRequest">Request delegate</param>
+    public HttpClientHandlerStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) {
+      ExecuteRequest = executeRequest;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+      HttpResponseMessage reply = ExecuteRequest?.Invoke(request);
+
+      return Task.FromResult(reply);
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
@@ -1,63 +1,72 @@
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace YouTrackSharp.Tests.Infrastructure {
-  /// <summary>
-  /// Connection mock used to return predefined HTTP responses, for testing purposes.
-  /// </summary>
-  public class ConnectionStub : Connection {
-    private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
+namespace YouTrackSharp.Tests.Infrastructure
+{
+    /// <summary>
+    /// Connection mock used to return predefined HTTP responses, for testing purposes.
+    /// </summary>
+    public class ConnectionStub : Connection
+    {
+        private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
 
-    private TimeSpan TimeOut => TimeSpan.FromSeconds(100);
+        private TimeSpan TimeOut => TimeSpan.FromSeconds(100);
+
+        /// <summary>
+        /// Creates an instance of <see cref="ConnectionStub"/> with give response delegate
+        /// </summary>
+        /// <param name="executeRequest">Request delegate</param>
+        public ConnectionStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) : base(
+            "http://fake.connection.com/")
+        {
+            ExecuteRequest = executeRequest;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="HttpClient"/> configured to return a predefined message and HTTP status
+        /// on request.
+        /// </summary>
+        /// <returns><see cref="HttpClient"/> configured to return a predefined message and HTTP status</returns>
+        public override Task<HttpClient> GetAuthenticatedHttpClient()
+        {
+            return Task.FromResult(CreateClient());
+        }
+
+        private HttpClient CreateClient()
+        {
+            HttpClient httpClient = new HttpClient(new HttpClientHandlerStub(ExecuteRequest));
+            httpClient.BaseAddress = ServerUri;
+            httpClient.Timeout = TimeOut;
+
+            return httpClient;
+        }
+    }
 
     /// <summary>
-    /// Creates an instance of <see cref="ConnectionStub"/> with give response delegate
+    /// <see cref="HttpClientHandler"/> mock, that returns a predefined reply and HTTP status code. 
     /// </summary>
-    /// <param name="executeRequest">Request delegate</param>
-    public ConnectionStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) : base("http://fake.connection.com/") {
-      ExecuteRequest = executeRequest;
-    }
-    
-    /// <summary>
-    /// Creates an <see cref="HttpClient"/> configured to return a predefined message and HTTP status
-    /// on request.
-    /// </summary>
-    /// <returns><see cref="HttpClient"/> configured to return a predefined message and HTTP status</returns>
-    public override Task<HttpClient> GetAuthenticatedHttpClient() {
-      return Task.FromResult(CreateClient());
-    }
+    public class HttpClientHandlerStub : HttpClientHandler
+    {
+        private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
 
-    private HttpClient CreateClient() {
-      HttpClient httpClient = new HttpClient(new HttpClientHandlerStub(ExecuteRequest));
-      httpClient.BaseAddress = ServerUri;
-      httpClient.Timeout = TimeOut;
+        /// <summary>
+        /// Creates an <see cref="HttpClientHandlerStub"/> instance that delegates HttpRequestMessages
+        /// </summary>
+        /// <param name="executeRequest">Request delegate</param>
+        public HttpClientHandlerStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest)
+        {
+            ExecuteRequest = executeRequest;
+        }
 
-      return httpClient;
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                                                               CancellationToken cancellationToken)
+        {
+            HttpResponseMessage reply = ExecuteRequest?.Invoke(request);
+
+            return Task.FromResult(reply);
+        }
     }
-  }
-
-  /// <summary>
-  /// <see cref="HttpClientHandler"/> mock, that returns a predefined reply and HTTP status code. 
-  /// </summary>
-  public class HttpClientHandlerStub : HttpClientHandler {
-    private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
-    
-    /// <summary>
-    /// Creates an <see cref="HttpClientHandlerStub"/> instance that delegates HttpRequestMessages
-    /// </summary>
-    /// <param name="executeRequest">Request delegate</param>
-    public HttpClientHandlerStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) {
-      ExecuteRequest = executeRequest;
-    }
-
-    /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-      HttpResponseMessage reply = ExecuteRequest?.Invoke(request);
-
-      return Task.FromResult(reply);
-    }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/ConnectionStub.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace YouTrackSharp.Tests.Infrastructure
@@ -10,18 +9,19 @@ namespace YouTrackSharp.Tests.Infrastructure
     /// </summary>
     public class ConnectionStub : Connection
     {
-        private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
-
+        private readonly HttpClientHandler _handler;
         private TimeSpan TimeOut => TimeSpan.FromSeconds(100);
 
         /// <summary>
         /// Creates an instance of <see cref="ConnectionStub"/> with give response delegate
         /// </summary>
-        /// <param name="executeRequest">Request delegate</param>
-        public ConnectionStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest) : base(
-            "http://fake.connection.com/")
+        /// <param name="handler">
+        /// <see cref="HttpClientHandler"/> to associate to this connection.
+        /// This can be used to pass a stub handler for testing purposes.
+        /// </param>
+        public ConnectionStub(HttpClientHandler handler) : base("http://fake.connection.com/")
         {
-            ExecuteRequest = executeRequest;
+            _handler = handler;
         }
 
         /// <summary>
@@ -31,42 +31,11 @@ namespace YouTrackSharp.Tests.Infrastructure
         /// <returns><see cref="HttpClient"/> configured to return a predefined message and HTTP status</returns>
         public override Task<HttpClient> GetAuthenticatedHttpClient()
         {
-            return Task.FromResult(CreateClient());
-        }
-
-        private HttpClient CreateClient()
-        {
-            HttpClient httpClient = new HttpClient(new HttpClientHandlerStub(ExecuteRequest));
+            HttpClient httpClient = new HttpClient(_handler);
             httpClient.BaseAddress = ServerUri;
             httpClient.Timeout = TimeOut;
-
-            return httpClient;
-        }
-    }
-
-    /// <summary>
-    /// <see cref="HttpClientHandler"/> mock, that returns a predefined reply and HTTP status code. 
-    /// </summary>
-    public class HttpClientHandlerStub : HttpClientHandler
-    {
-        private Func<HttpRequestMessage, HttpResponseMessage> ExecuteRequest { get; }
-
-        /// <summary>
-        /// Creates an <see cref="HttpClientHandlerStub"/> instance that delegates HttpRequestMessages
-        /// </summary>
-        /// <param name="executeRequest">Request delegate</param>
-        public HttpClientHandlerStub(Func<HttpRequestMessage, HttpResponseMessage> executeRequest)
-        {
-            ExecuteRequest = executeRequest;
-        }
-
-        /// <inheritdoc />
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-                                                               CancellationToken cancellationToken)
-        {
-            HttpResponseMessage reply = ExecuteRequest?.Invoke(request);
-
-            return Task.FromResult(reply);
+            
+            return Task.FromResult<HttpClient>(httpClient);
         }
     }
 }

--- a/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
@@ -26,12 +26,12 @@ namespace YouTrackSharp.Tests.Infrastructure
         
         public static Connection ConnectionStub(string content, HttpStatusCode status = HttpStatusCode.OK)
         {
-          HttpResponseMessage response = new HttpResponseMessage(status);
-          response.Content = new StringContent(content);
-          
-          return new ConnectionStub(_ => response);
+            HttpResponseMessage response = new HttpResponseMessage(status);
+            response.Content = new StringContent(content);
+            
+            return new ConnectionStub(_ => response);
         } 
-        
+  
         public static class TestData
         {
             public static readonly List<object[]> ValidConnections

--- a/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
 using System.Security.Authentication;
 
@@ -22,7 +23,14 @@ namespace YouTrackSharp.Tests.Infrastructure
 
         public static Connection Demo3Token => 
             new BearerTokenConnection(ServerUrl, "perm:ZGVtbzM=.WW91VHJhY2tTaGFycA==.L04RdcCnjyW2UPCVg1qyb6dQflpzFy", ConfigureTestsHandler);
-
+        
+        public static Connection ConnectionStub(string content, HttpStatusCode status = HttpStatusCode.OK) {
+          HttpResponseMessage response = new HttpResponseMessage(status);
+          response.Content = new StringContent(content);
+          
+          return new ConnectionStub(_ => response);
+        } 
+        
         public static class TestData
         {
             public static readonly List<object[]> ValidConnections

--- a/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
@@ -23,14 +23,6 @@ namespace YouTrackSharp.Tests.Infrastructure
 
         public static Connection Demo3Token => 
             new BearerTokenConnection(ServerUrl, "perm:ZGVtbzM=.WW91VHJhY2tTaGFycA==.L04RdcCnjyW2UPCVg1qyb6dQflpzFy", ConfigureTestsHandler);
-        
-        public static Connection ConnectionStub(string content, HttpStatusCode status = HttpStatusCode.OK)
-        {
-            HttpResponseMessage response = new HttpResponseMessage(status);
-            response.Content = new StringContent(content);
-            
-            return new ConnectionStub(_ => response);
-        } 
   
         public static class TestData
         {

--- a/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/Connections.cs
@@ -24,7 +24,8 @@ namespace YouTrackSharp.Tests.Infrastructure
         public static Connection Demo3Token => 
             new BearerTokenConnection(ServerUrl, "perm:ZGVtbzM=.WW91VHJhY2tTaGFycA==.L04RdcCnjyW2UPCVg1qyb6dQflpzFy", ConfigureTestsHandler);
         
-        public static Connection ConnectionStub(string content, HttpStatusCode status = HttpStatusCode.OK) {
+        public static Connection ConnectionStub(string content, HttpStatusCode status = HttpStatusCode.OK)
+        {
           HttpResponseMessage response = new HttpResponseMessage(status);
           response.Content = new StringContent(content);
           

--- a/tests/YouTrackSharp.Tests/Infrastructure/JsonArrayHandler.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/JsonArrayHandler.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YouTrackSharp.Tests.Infrastructure
+{
+    /// <summary>
+    /// This handler is used to return a json array from a range of give json strings, created from the $top and $skip
+    /// parameters of the HTTP request.
+    /// This handler can be used to simulate a server returning json arrays in batches. 
+    /// </summary>
+    public class JsonArrayHandler : HttpClientHandler
+    {
+        private readonly ICollection<string> _jsonObjects;
+        public int RequestsReceived { get; private set; }
+
+        /// <summary>
+        /// Creates an instance of <see cref="JsonArrayHandler"/>
+        /// </summary>
+        /// <param name="jsonObjects">List of json objects that this instance will pick from</param>
+        public JsonArrayHandler(params string[] jsonObjects)
+        {
+            _jsonObjects = jsonObjects;
+            RequestsReceived = 0;
+        }
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestsReceived++;
+            
+            GetRequestedRange(request, _jsonObjects.Count, out int skip, out int count);
+            string json = GetJsonArray(_jsonObjects, skip, count);
+
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Content = new StringContent(json);
+
+            return Task.FromResult(response);
+        }
+
+        /// <summary>
+        /// Creates a JSON array from a range of the given json strings.
+        /// This allows to simulate returning a total number of elements, in batches. 
+        /// </summary>
+        /// <param name="jsonObjects">JSON objects from which the JSON array will be created</param>
+        /// <param name="skip">Number of items to skip</param>
+        /// <param name="count">Number of items to return</param>
+        /// <returns>
+        /// Json array
+        /// </returns>
+        private string GetJsonArray(ICollection<string> jsonObjects, int skip, int count)
+        {
+            IEnumerable<string> jsonObjectRange = jsonObjects.Skip(skip).Take(count);
+            string json = $"[{string.Join(",", jsonObjectRange)}]";
+
+            return json;
+        }
+
+        /// <summary>
+        /// Parses the $skip and $top parameters from a Youtrack REST request URI, and computes the requested range
+        /// of objects to return (capped by <see cref="maxIndex"/>).
+        /// </summary>
+        /// <param name="request">HTTP request</param>
+        /// <param name="maxIndex">Max index (range will not go beyond that index, even if $skip + $top is greater</param>
+        /// <param name="skip">Number of items to skip</param>
+        /// <param name="count">Number of items to return</param>
+        /// <returns>Range computed from request's $skip and $top</returns>
+        private void GetRequestedRange(HttpRequestMessage request, int maxIndex, out int skip, out int count)
+        {
+            string requestUri = request.RequestUri.ToString();
+
+            Match match = Regex.Match(requestUri, "&\\$top=(?<top>[0-9]+)(&\\$skip=(?<skip>[0-9]+))?|&\\$skip=(?<skip>[0-9]+)(&\\$top=(?<top>[0-9]+))?");
+
+            count = maxIndex;
+            if (match.Groups.ContainsKey("top") && match.Groups["top"].Success)
+            {
+                count = int.Parse(match.Groups["top"].Value);
+            }
+
+            skip = 0;
+            if (match.Groups.ContainsKey("skip") && match.Groups["skip"].Success)
+            {
+                skip = int.Parse(match.Groups["skip"].Value);
+            }
+        }
+    }
+}

--- a/tests/YouTrackSharp.Tests/Infrastructure/JsonHandler.cs
+++ b/tests/YouTrackSharp.Tests/Infrastructure/JsonHandler.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YouTrackSharp.Tests.Infrastructure
+{
+    /// <summary>
+    /// This handler returns a predefined json string on every request.
+    /// </summary>
+    public class JsonHandler : HttpClientHandler
+    {
+        private readonly string _json;
+
+        /// <summary>
+        /// Creates an instance of <see cref="JsonHandler"/>
+        /// </summary>
+        /// <param name="json">Json string that will be returned upon each request</param>
+        public JsonHandler(string json)
+        {
+            _json = json;
+        }
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Content = new StringContent(_json);
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using YouTrackSharp.Tests.Infrastructure;
+
+namespace YouTrackSharp.Tests.Integration.Agiles {
+  public partial class AgileServiceTest {
+    private static string DemoBoardId => "108-2";
+    private static string DemoBoardNamePrefix => "Test Board597fb561-ea1f-4095-9636-859ae4439605";
+
+    private static string DemoSprintId => "109-2";
+    private static string DemoSprintName => "First sprint";
+
+    private static string CompleteAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
+
+    private static string GetTextResource(string name) {
+      Assembly assembly = Assembly.GetExecutingAssembly();
+
+      using Stream stream = assembly.GetManifestResourceStream(name);
+      if (stream == null) return string.Empty;
+      
+      using StreamReader reader = new StreamReader(stream);
+      
+      return reader.ReadToEnd();
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
@@ -8,20 +8,12 @@ namespace YouTrackSharp.Tests.Integration.Agiles
     {
         private static string DemoBoardId => "108-2";
         private static string DemoBoardNamePrefix => "Test Board597fb561-ea1f-4095-9636-859ae4439605";
-
+        
         private static string DemoSprintId => "109-2";
         private static string DemoSprintName => "First sprint";
 
-        private static string SingleAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
-
-        private static string GetAgileJsonArray(int count)
-        {
-            string agileJson = SingleAgileJson;
-
-            string agilesJson = string.Join(",", Enumerable.Range(0, count).Select(_ => agileJson));
-
-            return $"[{agilesJson}]";
-        }
+        private static string FullAgile01 => GetTextResource("YouTrackSharp.Tests.Resources.FullAgile01.json");
+        private static string FullAgile02 => GetTextResource("YouTrackSharp.Tests.Resources.FullAgile02.json");
 
         private static string GetTextResource(string name)
         {

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace YouTrackSharp.Tests.Integration.Agiles
@@ -11,7 +12,16 @@ namespace YouTrackSharp.Tests.Integration.Agiles
         private static string DemoSprintId => "109-2";
         private static string DemoSprintName => "First sprint";
 
-        private static string CompleteAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
+        private static string SingleAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
+
+        private static string GetAgileJsonArray(int count)
+        {
+            string agileJson = SingleAgileJson;
+
+            string agilesJson = string.Join(",", Enumerable.Range(0, count).Select(_ => agileJson));
+
+            return $"[{agilesJson}]";
+        }
 
         private static string GetTextResource(string name)
         {

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/AgileServiceTest.cs
@@ -1,28 +1,31 @@
 using System.IO;
-using System.Net;
-using System.Net.Http;
 using System.Reflection;
-using YouTrackSharp.Tests.Infrastructure;
 
-namespace YouTrackSharp.Tests.Integration.Agiles {
-  public partial class AgileServiceTest {
-    private static string DemoBoardId => "108-2";
-    private static string DemoBoardNamePrefix => "Test Board597fb561-ea1f-4095-9636-859ae4439605";
+namespace YouTrackSharp.Tests.Integration.Agiles
+{
+    public partial class AgileServiceTest
+    {
+        private static string DemoBoardId => "108-2";
+        private static string DemoBoardNamePrefix => "Test Board597fb561-ea1f-4095-9636-859ae4439605";
 
-    private static string DemoSprintId => "109-2";
-    private static string DemoSprintName => "First sprint";
+        private static string DemoSprintId => "109-2";
+        private static string DemoSprintName => "First sprint";
 
-    private static string CompleteAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
+        private static string CompleteAgileJson => GetTextResource("YouTrackSharp.Tests.Resources.CompleteAgile.json");
 
-    private static string GetTextResource(string name) {
-      Assembly assembly = Assembly.GetExecutingAssembly();
+        private static string GetTextResource(string name)
+        {
+            Assembly assembly = Assembly.GetExecutingAssembly();
 
-      using Stream stream = assembly.GetManifestResourceStream(name);
-      if (stream == null) return string.Empty;
-      
-      using StreamReader reader = new StreamReader(stream);
-      
-      return reader.ReadToEnd();
+            using Stream stream = assembly.GetManifestResourceStream(name);
+            if (stream == null)
+            {
+                return string.Empty;
+            }
+
+            using StreamReader reader = new StreamReader(stream);
+
+            return reader.ReadToEnd();
+        }
     }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Xunit;
+using YouTrackSharp.Agiles;
+using YouTrackSharp.Tests.Infrastructure;
+
+namespace YouTrackSharp.Tests.Integration.Agiles {
+  [UsedImplicitly]
+  public partial class AgileServiceTest {
+    public class GetAgiles {
+      [Fact]
+      public async Task Valid_Connection_Return_Existing_Agile_Verbose() {
+        // Arrange
+        IAgileService agileService = Connections.Demo1Token.CreateAgileService();
+
+        // Act
+        ICollection<Agile> result = await agileService.GetAgileBoards(true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        Agile demoBoard = result.FirstOrDefault();
+        Assert.NotNull(demoBoard);
+        Assert.Equal(DemoBoardId, demoBoard.Id);
+        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+
+        Assert.NotNull(demoBoard.ColumnSettings);
+        Assert.NotNull(demoBoard.Projects);
+        Assert.NotNull(demoBoard.Sprints);
+        Assert.NotNull(demoBoard.Projects);
+        Assert.NotNull(demoBoard.Sprints);
+        Assert.NotNull(demoBoard.Status);
+
+        Assert.NotNull(demoBoard.ColumnSettings);
+        Assert.NotNull(demoBoard.CurrentSprint);
+        Assert.NotNull(demoBoard.EstimationField);
+        Assert.NotNull(demoBoard.SprintsSettings);
+        Assert.NotNull(demoBoard.SwimlaneSettings);
+
+
+        // These fields are null in the agile test
+        Assert.Null(demoBoard.ColorCoding);
+        Assert.Null(demoBoard.UpdateableBy);
+        Assert.Null(demoBoard.VisibleFor);
+        Assert.Null(demoBoard.OriginalEstimationField);
+
+        Sprint sprint = demoBoard.Sprints.FirstOrDefault();
+        Assert.NotNull(sprint);
+        Assert.Equal(DemoSprintId, sprint.Id);
+        Assert.Equal(DemoSprintName, sprint.Name);
+      }
+
+      [Fact]
+      public async Task Verbose_Disabled_Returns_Agile_Minimum_Info() {
+        // Arrange
+        IAgileService agileService = Connections.Demo1Token.CreateAgileService();
+
+        // Act
+        ICollection<Agile> result = await agileService.GetAgileBoards(false);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        Agile demoBoard = result.FirstOrDefault();
+        Assert.NotNull(demoBoard);
+
+        Assert.Equal(DemoBoardId, demoBoard.Id);
+        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+      }
+
+      [Fact]
+      public async Task Invalid_Connection_Throws_UnauthorizedConnectionException() {
+        // Arrange
+        IAgileService agileService = Connections.UnauthorizedConnection.CreateAgileService();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedConnectionException>(async () => await agileService.GetAgileBoards());
+      }
+      
+      [Fact]
+      public async Task Full_Agile_Json_Gets_Deserialized_Successfully() {
+        // Arrange
+        IAgileService agileService = Connections.ConnectionStub(CompleteAgileJson).CreateAgileService();
+
+        // Act
+        ICollection<Agile> result = await agileService.GetAgileBoards(true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        Agile demoBoard = result.FirstOrDefault();
+        Assert.NotNull(demoBoard);
+        Assert.Equal(DemoBoardId, demoBoard.Id);
+        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+
+        Assert.NotNull(demoBoard.ColumnSettings);
+        Assert.NotNull(demoBoard.Projects);
+        Assert.NotNull(demoBoard.Sprints);
+        Assert.NotNull(demoBoard.Projects);
+        Assert.NotNull(demoBoard.Sprints);
+        Assert.NotNull(demoBoard.Status);
+        Assert.NotNull(demoBoard.ColumnSettings);
+        Assert.NotNull(demoBoard.CurrentSprint);
+        Assert.NotNull(demoBoard.EstimationField);
+        Assert.NotNull(demoBoard.SprintsSettings);
+        Assert.NotNull(demoBoard.SwimlaneSettings);
+        Assert.NotNull(demoBoard.ColorCoding);
+        Assert.NotNull(demoBoard.UpdateableBy);
+        Assert.NotNull(demoBoard.VisibleFor);
+        Assert.NotNull(demoBoard.OriginalEstimationField);
+
+        Sprint sprint = demoBoard.Sprints.FirstOrDefault();
+        Assert.NotNull(sprint);
+        Assert.Equal(DemoSprintId, sprint.Id);
+        Assert.Equal(DemoSprintName, sprint.Name);
+      }
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
@@ -63,43 +63,65 @@ namespace YouTrackSharp.Tests.Integration.Agiles
             }
 
             [Fact]
-            public async Task Full_Agile_Json_Gets_Deserialized_Successfully()
+            public async Task Mock_Connection_Returns_Full_Agiles()
             {
                 // Arrange
-                IAgileService agileService = Connections.ConnectionStub(GetAgileJsonArray(1)).CreateAgileService();
+                string[] strings = { FullAgile01, FullAgile02 };
+
+                JsonArrayHandler handler = new JsonArrayHandler(strings);
+                ConnectionStub connection = new ConnectionStub(handler);
+                
+                IAgileService agileService = connection.CreateAgileService();
 
                 // Act
                 ICollection<Agile> result = await agileService.GetAgileBoards(true);
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.NotEmpty(result);
+                Assert.Equal(2, result.Count);
 
-                Agile demoBoard = result.FirstOrDefault();
-                Assert.NotNull(demoBoard);
-                Assert.Equal(DemoBoardId, demoBoard.Id);
-                Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+                foreach (Agile agile in result)
+                {
+                    Assert.NotNull(agile);
+                    
+                    Assert.True("109-1".Equals(agile.Id) || "109-2".Equals(agile.Id));
 
-                Assert.NotNull(demoBoard.ColumnSettings);
-                Assert.NotNull(demoBoard.Projects);
-                Assert.NotNull(demoBoard.Sprints);
-                Assert.NotNull(demoBoard.Projects);
-                Assert.NotNull(demoBoard.Sprints);
-                Assert.NotNull(demoBoard.Status);
-                Assert.NotNull(demoBoard.ColumnSettings);
-                Assert.NotNull(demoBoard.CurrentSprint);
-                Assert.NotNull(demoBoard.EstimationField);
-                Assert.NotNull(demoBoard.SprintsSettings);
-                Assert.NotNull(demoBoard.SwimlaneSettings);
-                Assert.NotNull(demoBoard.ColorCoding);
-                Assert.NotNull(demoBoard.UpdateableBy);
-                Assert.NotNull(demoBoard.VisibleFor);
-                Assert.NotNull(demoBoard.OriginalEstimationField);
+                    Assert.NotNull(agile.ColumnSettings);
+                    Assert.NotNull(agile.Projects);
+                    Assert.NotNull(agile.Sprints);
+                    Assert.NotNull(agile.Projects);
+                    Assert.NotNull(agile.Sprints);
+                    Assert.NotNull(agile.Status);
+                    Assert.NotNull(agile.ColumnSettings);
+                    Assert.NotNull(agile.CurrentSprint);
+                    Assert.NotNull(agile.EstimationField);
+                    Assert.NotNull(agile.SprintsSettings);
+                    Assert.NotNull(agile.SwimlaneSettings);
+                    Assert.NotNull(agile.ColorCoding);
+                    Assert.NotNull(agile.UpdateableBy);
+                    Assert.NotNull(agile.VisibleFor);
+                    Assert.NotNull(agile.OriginalEstimationField);
 
-                Sprint sprint = demoBoard.Sprints.FirstOrDefault();
-                Assert.NotNull(sprint);
-                Assert.Equal(DemoSprintId, sprint.Id);
-                Assert.Equal(DemoSprintName, sprint.Name);
+                    Sprint sprint = agile.Sprints.FirstOrDefault();
+                    Assert.NotNull(sprint);
+                    Assert.Equal(DemoSprintId, sprint.Id);
+                    Assert.Equal(DemoSprintName, sprint.Name);
+
+                    if ("109-1".Equals(agile.Id))
+                    {
+                        Assert.Equal("Full Board 01", agile.Name);
+                        Assert.IsType<FieldBasedColorCoding>(agile.ColorCoding);
+                        Assert.IsType<IssueBasedSwimlaneSettings>(agile.SwimlaneSettings);
+                        Assert.IsType<CustomFilterField>(((IssueBasedSwimlaneSettings)agile.SwimlaneSettings).Field);    
+                    }
+                    else
+                    {
+                        Assert.Equal("Full Board 02", agile.Name);
+                        Assert.IsType<ProjectBasedColorCoding>(agile.ColorCoding);
+                        Assert.IsType<AttributeBasedSwimlaneSettings>(agile.SwimlaneSettings);
+                        Assert.IsType<PredefinedFilterField>(((AttributeBasedSwimlaneSettings)agile.SwimlaneSettings).Field);
+                    }
+                }   
             }
         }
     }

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
@@ -6,119 +6,127 @@ using Xunit;
 using YouTrackSharp.Agiles;
 using YouTrackSharp.Tests.Infrastructure;
 
-namespace YouTrackSharp.Tests.Integration.Agiles {
-  [UsedImplicitly]
-  public partial class AgileServiceTest {
-    public class GetAgiles {
-      [Fact]
-      public async Task Valid_Connection_Return_Existing_Agile_Verbose() {
-        // Arrange
-        IAgileService agileService = Connections.Demo1Token.CreateAgileService();
+namespace YouTrackSharp.Tests.Integration.Agiles
+{
+    [UsedImplicitly]
+    public partial class AgileServiceTest
+    {
+        public class GetAgiles
+        {
+            [Fact]
+            public async Task Valid_Connection_Return_Existing_Agile_Verbose()
+            {
+                // Arrange
+                IAgileService agileService = Connections.Demo1Token.CreateAgileService();
 
-        // Act
-        ICollection<Agile> result = await agileService.GetAgileBoards(true);
+                // Act
+                ICollection<Agile> result = await agileService.GetAgileBoards(true);
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotEmpty(result);
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
 
-        Agile demoBoard = result.FirstOrDefault();
-        Assert.NotNull(demoBoard);
-        Assert.Equal(DemoBoardId, demoBoard.Id);
-        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+                Agile demoBoard = result.FirstOrDefault();
+                Assert.NotNull(demoBoard);
+                Assert.Equal(DemoBoardId, demoBoard.Id);
+                Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
 
-        Assert.NotNull(demoBoard.ColumnSettings);
-        Assert.NotNull(demoBoard.Projects);
-        Assert.NotNull(demoBoard.Sprints);
-        Assert.NotNull(demoBoard.Projects);
-        Assert.NotNull(demoBoard.Sprints);
-        Assert.NotNull(demoBoard.Status);
+                Assert.NotNull(demoBoard.ColumnSettings);
+                Assert.NotNull(demoBoard.Projects);
+                Assert.NotNull(demoBoard.Sprints);
+                Assert.NotNull(demoBoard.Projects);
+                Assert.NotNull(demoBoard.Sprints);
+                Assert.NotNull(demoBoard.Status);
 
-        Assert.NotNull(demoBoard.ColumnSettings);
-        Assert.NotNull(demoBoard.CurrentSprint);
-        Assert.NotNull(demoBoard.EstimationField);
-        Assert.NotNull(demoBoard.SprintsSettings);
-        Assert.NotNull(demoBoard.SwimlaneSettings);
+                Assert.NotNull(demoBoard.ColumnSettings);
+                Assert.NotNull(demoBoard.CurrentSprint);
+                Assert.NotNull(demoBoard.EstimationField);
+                Assert.NotNull(demoBoard.SprintsSettings);
+                Assert.NotNull(demoBoard.SwimlaneSettings);
 
 
-        // These fields are null in the agile test
-        Assert.Null(demoBoard.ColorCoding);
-        Assert.Null(demoBoard.UpdateableBy);
-        Assert.Null(demoBoard.VisibleFor);
-        Assert.Null(demoBoard.OriginalEstimationField);
+                // These fields are null in the agile test
+                Assert.Null(demoBoard.ColorCoding);
+                Assert.Null(demoBoard.UpdateableBy);
+                Assert.Null(demoBoard.VisibleFor);
+                Assert.Null(demoBoard.OriginalEstimationField);
 
-        Sprint sprint = demoBoard.Sprints.FirstOrDefault();
-        Assert.NotNull(sprint);
-        Assert.Equal(DemoSprintId, sprint.Id);
-        Assert.Equal(DemoSprintName, sprint.Name);
-      }
+                Sprint sprint = demoBoard.Sprints.FirstOrDefault();
+                Assert.NotNull(sprint);
+                Assert.Equal(DemoSprintId, sprint.Id);
+                Assert.Equal(DemoSprintName, sprint.Name);
+            }
 
-      [Fact]
-      public async Task Verbose_Disabled_Returns_Agile_Minimum_Info() {
-        // Arrange
-        IAgileService agileService = Connections.Demo1Token.CreateAgileService();
+            [Fact]
+            public async Task Verbose_Disabled_Returns_Agile_Minimum_Info()
+            {
+                // Arrange
+                IAgileService agileService = Connections.Demo1Token.CreateAgileService();
 
-        // Act
-        ICollection<Agile> result = await agileService.GetAgileBoards(false);
+                // Act
+                ICollection<Agile> result = await agileService.GetAgileBoards(false);
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotEmpty(result);
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
 
-        Agile demoBoard = result.FirstOrDefault();
-        Assert.NotNull(demoBoard);
+                Agile demoBoard = result.FirstOrDefault();
+                Assert.NotNull(demoBoard);
 
-        Assert.Equal(DemoBoardId, demoBoard.Id);
-        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
-      }
+                Assert.Equal(DemoBoardId, demoBoard.Id);
+                Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+            }
 
-      [Fact]
-      public async Task Invalid_Connection_Throws_UnauthorizedConnectionException() {
-        // Arrange
-        IAgileService agileService = Connections.UnauthorizedConnection.CreateAgileService();
+            [Fact]
+            public async Task Invalid_Connection_Throws_UnauthorizedConnectionException()
+            {
+                // Arrange
+                IAgileService agileService = Connections.UnauthorizedConnection.CreateAgileService();
 
-        // Act & Assert
-        await Assert.ThrowsAsync<UnauthorizedConnectionException>(async () => await agileService.GetAgileBoards());
-      }
-      
-      [Fact]
-      public async Task Full_Agile_Json_Gets_Deserialized_Successfully() {
-        // Arrange
-        IAgileService agileService = Connections.ConnectionStub(CompleteAgileJson).CreateAgileService();
+                // Act & Assert
+                await Assert.ThrowsAsync<UnauthorizedConnectionException>(
+                    async () => await agileService.GetAgileBoards());
+            }
 
-        // Act
-        ICollection<Agile> result = await agileService.GetAgileBoards(true);
+            [Fact]
+            public async Task Full_Agile_Json_Gets_Deserialized_Successfully()
+            {
+                // Arrange
+                IAgileService agileService = Connections.ConnectionStub(CompleteAgileJson).CreateAgileService();
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotEmpty(result);
+                // Act
+                ICollection<Agile> result = await agileService.GetAgileBoards(true);
 
-        Agile demoBoard = result.FirstOrDefault();
-        Assert.NotNull(demoBoard);
-        Assert.Equal(DemoBoardId, demoBoard.Id);
-        Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
 
-        Assert.NotNull(demoBoard.ColumnSettings);
-        Assert.NotNull(demoBoard.Projects);
-        Assert.NotNull(demoBoard.Sprints);
-        Assert.NotNull(demoBoard.Projects);
-        Assert.NotNull(demoBoard.Sprints);
-        Assert.NotNull(demoBoard.Status);
-        Assert.NotNull(demoBoard.ColumnSettings);
-        Assert.NotNull(demoBoard.CurrentSprint);
-        Assert.NotNull(demoBoard.EstimationField);
-        Assert.NotNull(demoBoard.SprintsSettings);
-        Assert.NotNull(demoBoard.SwimlaneSettings);
-        Assert.NotNull(demoBoard.ColorCoding);
-        Assert.NotNull(demoBoard.UpdateableBy);
-        Assert.NotNull(demoBoard.VisibleFor);
-        Assert.NotNull(demoBoard.OriginalEstimationField);
+                Agile demoBoard = result.FirstOrDefault();
+                Assert.NotNull(demoBoard);
+                Assert.Equal(DemoBoardId, demoBoard.Id);
+                Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
 
-        Sprint sprint = demoBoard.Sprints.FirstOrDefault();
-        Assert.NotNull(sprint);
-        Assert.Equal(DemoSprintId, sprint.Id);
-        Assert.Equal(DemoSprintName, sprint.Name);
-      }
+                Assert.NotNull(demoBoard.ColumnSettings);
+                Assert.NotNull(demoBoard.Projects);
+                Assert.NotNull(demoBoard.Sprints);
+                Assert.NotNull(demoBoard.Projects);
+                Assert.NotNull(demoBoard.Sprints);
+                Assert.NotNull(demoBoard.Status);
+                Assert.NotNull(demoBoard.ColumnSettings);
+                Assert.NotNull(demoBoard.CurrentSprint);
+                Assert.NotNull(demoBoard.EstimationField);
+                Assert.NotNull(demoBoard.SprintsSettings);
+                Assert.NotNull(demoBoard.SwimlaneSettings);
+                Assert.NotNull(demoBoard.ColorCoding);
+                Assert.NotNull(demoBoard.UpdateableBy);
+                Assert.NotNull(demoBoard.VisibleFor);
+                Assert.NotNull(demoBoard.OriginalEstimationField);
+
+                Sprint sprint = demoBoard.Sprints.FirstOrDefault();
+                Assert.NotNull(sprint);
+                Assert.Equal(DemoSprintId, sprint.Id);
+                Assert.Equal(DemoSprintName, sprint.Name);
+            }
+        }
     }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgiles.cs
@@ -14,7 +14,7 @@ namespace YouTrackSharp.Tests.Integration.Agiles
         public class GetAgiles
         {
             [Fact]
-            public async Task Valid_Connection_Return_Existing_Agile_Verbose()
+            public async Task Valid_Connection_Return_Existing_Agiles_Verbose()
             {
                 // Arrange
                 IAgileService agileService = Connections.Demo1Token.CreateAgileService();
@@ -30,35 +30,10 @@ namespace YouTrackSharp.Tests.Integration.Agiles
                 Assert.NotNull(demoBoard);
                 Assert.Equal(DemoBoardId, demoBoard.Id);
                 Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
-
-                Assert.NotNull(demoBoard.ColumnSettings);
-                Assert.NotNull(demoBoard.Projects);
-                Assert.NotNull(demoBoard.Sprints);
-                Assert.NotNull(demoBoard.Projects);
-                Assert.NotNull(demoBoard.Sprints);
-                Assert.NotNull(demoBoard.Status);
-
-                Assert.NotNull(demoBoard.ColumnSettings);
-                Assert.NotNull(demoBoard.CurrentSprint);
-                Assert.NotNull(demoBoard.EstimationField);
-                Assert.NotNull(demoBoard.SprintsSettings);
-                Assert.NotNull(demoBoard.SwimlaneSettings);
-
-
-                // These fields are null in the agile test
-                Assert.Null(demoBoard.ColorCoding);
-                Assert.Null(demoBoard.UpdateableBy);
-                Assert.Null(demoBoard.VisibleFor);
-                Assert.Null(demoBoard.OriginalEstimationField);
-
-                Sprint sprint = demoBoard.Sprints.FirstOrDefault();
-                Assert.NotNull(sprint);
-                Assert.Equal(DemoSprintId, sprint.Id);
-                Assert.Equal(DemoSprintName, sprint.Name);
             }
 
             [Fact]
-            public async Task Verbose_Disabled_Returns_Agile_Minimum_Info()
+            public async Task Verbose_Disabled_Returns_Agiles_Non_Verbose()
             {
                 // Arrange
                 IAgileService agileService = Connections.Demo1Token.CreateAgileService();
@@ -72,7 +47,6 @@ namespace YouTrackSharp.Tests.Integration.Agiles
 
                 Agile demoBoard = result.FirstOrDefault();
                 Assert.NotNull(demoBoard);
-
                 Assert.Equal(DemoBoardId, demoBoard.Id);
                 Assert.Equal(DemoBoardNamePrefix, demoBoard.Name);
             }
@@ -92,7 +66,7 @@ namespace YouTrackSharp.Tests.Integration.Agiles
             public async Task Full_Agile_Json_Gets_Deserialized_Successfully()
             {
                 // Arrange
-                IAgileService agileService = Connections.ConnectionStub(CompleteAgileJson).CreateAgileService();
+                IAgileService agileService = Connections.ConnectionStub(GetAgileJsonArray(1)).CreateAgileService();
 
                 // Act
                 ICollection<Agile> result = await agileService.GetAgileBoards(true);

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgilesInMultipleBatches.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgilesInMultipleBatches.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+using YouTrackSharp.Agiles;
+using YouTrackSharp.Tests.Infrastructure;
+
+namespace YouTrackSharp.Tests.Integration.Agiles
+{
+    public partial class AgileServiceTest
+    {
+        public class GetAgilesInMultipleBatches
+        {
+            /// <summary>
+            /// Creates a JSON array of Agile objects, whose size is determined by the "$top" and "$skip" parameters
+            /// of the request (with a maximum of <see cref="totalAgiles"/> - skipped).<br></br>
+            /// This allows to simulate returning a total number of agiles, in batches (the size of the batch is
+            /// determined by the <see cref="AgileService"/> itself. 
+            /// </summary>
+            /// <param name="request">REST request, with the $top parameter indicating the max number of results</param>
+            /// <param name="totalAgiles">Total number of agiles to simulate in the server</param>
+            /// <returns>
+            /// Json array of agiles, whose size is hose size is determined by the "$top" and "$skip" parameters of the
+            /// request (with a maximum of <see cref="totalAgiles"/> - skipped)
+            /// </returns>
+            private HttpResponseMessage GetAgileBatch(HttpRequestMessage request, int totalAgiles)
+            {
+                string requestUri = request.RequestUri.ToString();
+
+                Match match = Regex.Match(requestUri, "(&\\$top=(?<top>[0-9]+))?(&\\$skip=(?<skip>[0-9]+))?");
+
+                int top = totalAgiles;
+                if (match.Groups.ContainsKey("top") && match.Groups["top"].Success)
+                {
+                    top = int.Parse(match.Groups["top"].Value);
+                }
+
+                int skip = 0;
+                if (match.Groups.ContainsKey("skip") && match.Groups["skip"].Success)
+                {
+                    skip = int.Parse(match.Groups["skip"].Value);
+                }
+
+                int batchSize = Math.Min(top, totalAgiles - skip);
+                
+                string agileJsonArray = GetAgileJsonArray(batchSize);
+                HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
+                response.Content = new StringContent(agileJsonArray);
+
+                return response;
+            }
+
+            [Fact]
+            public async Task Many_Agiles_Are_Fetched_In_Batches()
+            {
+                // Arrange
+                const int totalAgileCount = 53;
+                Connection connection = new ConnectionStub(request => GetAgileBatch(request, totalAgileCount));
+                IAgileService agileService = connection.CreateAgileService();
+
+                // Act
+                ICollection<Agile> result = await agileService.GetAgileBoards(true);
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
+                Assert.Equal(totalAgileCount, result.Count);
+            }
+        }
+    }
+}

--- a/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgilesInMultipleBatches.cs
+++ b/tests/YouTrackSharp.Tests/Integration/Agiles/GetAgilesInMultipleBatches.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text.RegularExpressions;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using YouTrackSharp.Agiles;
@@ -14,51 +12,16 @@ namespace YouTrackSharp.Tests.Integration.Agiles
     {
         public class GetAgilesInMultipleBatches
         {
-            /// <summary>
-            /// Creates a JSON array of Agile objects, whose size is determined by the "$top" and "$skip" parameters
-            /// of the request (with a maximum of <see cref="totalAgiles"/> - skipped).<br></br>
-            /// This allows to simulate returning a total number of agiles, in batches (the size of the batch is
-            /// determined by the <see cref="AgileService"/> itself. 
-            /// </summary>
-            /// <param name="request">REST request, with the $top parameter indicating the max number of results</param>
-            /// <param name="totalAgiles">Total number of agiles to simulate in the server</param>
-            /// <returns>
-            /// Json array of agiles, whose size is hose size is determined by the "$top" and "$skip" parameters of the
-            /// request (with a maximum of <see cref="totalAgiles"/> - skipped)
-            /// </returns>
-            private HttpResponseMessage GetAgileBatch(HttpRequestMessage request, int totalAgiles)
-            {
-                string requestUri = request.RequestUri.ToString();
-
-                Match match = Regex.Match(requestUri, "(&\\$top=(?<top>[0-9]+))?(&\\$skip=(?<skip>[0-9]+))?");
-
-                int top = totalAgiles;
-                if (match.Groups.ContainsKey("top") && match.Groups["top"].Success)
-                {
-                    top = int.Parse(match.Groups["top"].Value);
-                }
-
-                int skip = 0;
-                if (match.Groups.ContainsKey("skip") && match.Groups["skip"].Success)
-                {
-                    skip = int.Parse(match.Groups["skip"].Value);
-                }
-
-                int batchSize = Math.Min(top, totalAgiles - skip);
-                
-                string agileJsonArray = GetAgileJsonArray(batchSize);
-                HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
-                response.Content = new StringContent(agileJsonArray);
-
-                return response;
-            }
-
             [Fact]
-            public async Task Many_Agiles_Are_Fetched_In_Batches()
+            public async Task Mock_Connection_Return_Many_Agiles_In_Batches()
             {
                 // Arrange
                 const int totalAgileCount = 53;
-                Connection connection = new ConnectionStub(request => GetAgileBatch(request, totalAgileCount));
+                int expectedRequests = (int)Math.Ceiling(totalAgileCount / 10.0);
+                
+                string[] jsonStrings = Enumerable.Range(0, totalAgileCount).Select(i => FullAgile01).ToArray();
+                JsonArrayHandler handler = new JsonArrayHandler(jsonStrings);
+                ConnectionStub connection = new ConnectionStub(handler);
                 IAgileService agileService = connection.CreateAgileService();
 
                 // Act
@@ -68,6 +31,7 @@ namespace YouTrackSharp.Tests.Integration.Agiles
                 Assert.NotNull(result);
                 Assert.NotEmpty(result);
                 Assert.Equal(totalAgileCount, result.Count);
+                Assert.Equal(expectedRequests, handler.RequestsReceived);
             }
         }
     }

--- a/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTestFixtures.cs
+++ b/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTestFixtures.cs
@@ -3,115 +3,127 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Tests.Internal {
-  [UsedImplicitly]
-  public class FieldSyntaxEncoderTestFixtures {
-    public class FlatType {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+namespace YouTrackSharp.Tests.Internal
+{
+    [UsedImplicitly]
+    public class FieldSyntaxEncoderTestFixtures
+    {
+        public class FlatType
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("name")]
-        public string Name { get; set; }
+            [JsonProperty("name")]
+            public string Name { get; set; }
 
-        [Verbose]
-        [JsonProperty("description")]
-        public string Description { get; set; }
-      }
+            [Verbose]
+            [JsonProperty("description")]
+            public string Description { get; set; }
+        }
 
-      public class NestedTypes {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        public class NestedTypes
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("name")]
-        public string Name { get; set; }
+            [JsonProperty("name")]
+            public string Name { get; set; }
 
-        [JsonProperty("info")]
-        public Info Info { get; set; }
-      }
+            [JsonProperty("info")]
+            public Info Info { get; set; }
+        }
 
-      public class DeepNestedTypes {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        public class DeepNestedTypes
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [Verbose]
-        [JsonProperty("name")]
-        public string Name { get; set; }
+            [Verbose]
+            [JsonProperty("name")]
+            public string Name { get; set; }
 
-        [JsonProperty("contact")]
-        public DetailedContact Contact { get; set; }
-      }
+            [JsonProperty("contact")]
+            public DetailedContact Contact { get; set; }
+        }
 
-      public class DeepNestedTypesWithInheritance {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        public class DeepNestedTypesWithInheritance
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("name")]
-        public string name { get; set; }
+            [JsonProperty("name")]
+            public string name { get; set; }
 
-        [JsonProperty("contact")]
-        public Contact Contact { get; set; }
-      }
+            [JsonProperty("contact")]
+            public Contact Contact { get; set; }
+        }
 
-      public class DeepNestedTypesWithCollection {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        public class DeepNestedTypesWithCollection
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("name")]
-        public string name { get; set; }
+            [JsonProperty("name")]
+            public string name { get; set; }
 
-        [JsonProperty("contacts")]
-        public IList<Contact> Contacts { get; set; }
-      }
+            [JsonProperty("contacts")]
+            public IList<Contact> Contacts { get; set; }
+        }
 
-      public class CyclicReference {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+        public class CyclicReference
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("name")]
-        public string name { get; set; }
-        
-        [Verbose]
-        [JsonProperty("cyclic")]
-        public CyclicReference Cyclic { get; set; }
-      }
+            [JsonProperty("name")]
+            public string name { get; set; }
 
-      [KnownType(typeof(SimpleContact))]
-      [KnownType(typeof(DetailedContact))]
-      public class Contact {
-        [JsonProperty("id")]
-        public int Id { get; set; }
-      }
+            [Verbose]
+            [JsonProperty("cyclic")]
+            public CyclicReference Cyclic { get; set; }
+        }
 
-      public class SimpleContact : Contact {
-        [JsonProperty("fullName")]
-        public string FullName { get; set; }
+        [KnownType(typeof(SimpleContact))]
+        [KnownType(typeof(DetailedContact))]
+        public class Contact
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+        }
 
-        [Verbose]
-        [JsonProperty("info")]
-        public string Info { get; set; }
-      }
+        public class SimpleContact : Contact
+        {
+            [JsonProperty("fullName")]
+            public string FullName { get; set; }
 
-      public class DetailedContact : Contact {
-        [JsonProperty("firstName")]
-        public string FirstName { get; set; }
+            [Verbose]
+            [JsonProperty("info")]
+            public string Info { get; set; }
+        }
 
-        [JsonProperty("lastName")]
-        public string LastName { get; set; }
+        public class DetailedContact : Contact
+        {
+            [JsonProperty("firstName")]
+            public string FirstName { get; set; }
 
-        [Verbose]
-        [JsonProperty("info")]
-        public Info Info { get; set; }
-      }
+            [JsonProperty("lastName")]
+            public string LastName { get; set; }
 
-      public class Info {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+            [Verbose]
+            [JsonProperty("info")]
+            public Info Info { get; set; }
+        }
 
-        [JsonProperty("address")]
-        public string Address { get; set; }
+        public class Info
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
 
-        [JsonProperty("phoneNumber")]
-        public string PhoneNumber { get; set; }
-      }
-  }
+            [JsonProperty("address")]
+            public string Address { get; set; }
+
+            [JsonProperty("phoneNumber")]
+            public string PhoneNumber { get; set; }
+        }
+    }
 }

--- a/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTestFixtures.cs
+++ b/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTestFixtures.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using YouTrackSharp.SerializationAttributes;
+
+namespace YouTrackSharp.Tests.Internal {
+  [UsedImplicitly]
+  public class FieldSyntaxEncoderTestFixtures {
+    public class FlatType {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [Verbose]
+        [JsonProperty("description")]
+        public string Description { get; set; }
+      }
+
+      public class NestedTypes {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("info")]
+        public Info Info { get; set; }
+      }
+
+      public class DeepNestedTypes {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [Verbose]
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("contact")]
+        public DetailedContact Contact { get; set; }
+      }
+
+      public class DeepNestedTypesWithInheritance {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string name { get; set; }
+
+        [JsonProperty("contact")]
+        public Contact Contact { get; set; }
+      }
+
+      public class DeepNestedTypesWithCollection {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string name { get; set; }
+
+        [JsonProperty("contacts")]
+        public IList<Contact> Contacts { get; set; }
+      }
+
+      public class CyclicReference {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string name { get; set; }
+        
+        [Verbose]
+        [JsonProperty("cyclic")]
+        public CyclicReference Cyclic { get; set; }
+      }
+
+      [KnownType(typeof(SimpleContact))]
+      [KnownType(typeof(DetailedContact))]
+      public class Contact {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+      }
+
+      public class SimpleContact : Contact {
+        [JsonProperty("fullName")]
+        public string FullName { get; set; }
+
+        [Verbose]
+        [JsonProperty("info")]
+        public string Info { get; set; }
+      }
+
+      public class DetailedContact : Contact {
+        [JsonProperty("firstName")]
+        public string FirstName { get; set; }
+
+        [JsonProperty("lastName")]
+        public string LastName { get; set; }
+
+        [Verbose]
+        [JsonProperty("info")]
+        public Info Info { get; set; }
+      }
+
+      public class Info {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("address")]
+        public string Address { get; set; }
+
+        [JsonProperty("phoneNumber")]
+        public string PhoneNumber { get; set; }
+      }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTests.cs
+++ b/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTests.cs
@@ -1,0 +1,150 @@
+using JetBrains.Annotations;
+using Xunit;
+using YouTrackSharp.Internal;
+
+namespace YouTrackSharp.Tests.Internal {
+  [UsedImplicitly]
+  public class FieldSyntaxEncoderTests {
+    public class UrlEncoding {
+      [Fact]
+      public void Encode_Flat_Type() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType));
+
+        string expected = "id,name,description";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Flat_Type_Non_Verbose() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
+
+        string expected = "id,name";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Single_Nested_Types() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.NestedTypes));
+
+        string expected = "id,name,info(id,address,phoneNumber)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Deep_Nested_Types() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes));
+
+        string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_With_Inheritance_Merges_Common_Field_Info() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithInheritance));
+
+        string expected = "id,name,contact(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_With_Collection() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithCollection));
+
+        string expected = "id,name,contacts(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_Max_Depth_0() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 0);
+
+        string expected = string.Empty;
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_Max_Depth_1() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 1);
+
+        string expected = "id,name,contact";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_Max_Depth_2() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 2);
+
+        string expected = "id,name,contact(firstName,lastName,info,id)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Types_Max_Depth_3() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 3);
+
+        string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Flat_Type_Not_Verbose() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
+
+        string expected = "id,name";
+
+        Assert.Equal(expected, encoded);
+      }
+
+      [Fact]
+      public void Encode_Nested_Type_Not_Verbose() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), false);
+
+        string expected = "id,contact(firstName,lastName,id)";
+
+        Assert.Equal(expected, encoded);
+      }
+     
+      [Fact]
+      public void Control_Cyclic_References_With_Max_Depth() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), true, 3);
+
+        string expected = "id,name,cyclic(id,name,cyclic(id,name,cyclic))";
+
+        Assert.Equal(expected, encoded);
+      }
+      
+      [Fact]
+      public void Skip_Cyclic_References_With_Verbose_Disabled() {
+        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), false);
+
+        string expected = "id,name";
+
+        Assert.Equal(expected, encoded);
+      }
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTests.cs
+++ b/tests/YouTrackSharp.Tests/Internal/FieldSyntaxEncoderTests.cs
@@ -2,149 +2,166 @@ using JetBrains.Annotations;
 using Xunit;
 using YouTrackSharp.Internal;
 
-namespace YouTrackSharp.Tests.Internal {
-  [UsedImplicitly]
-  public class FieldSyntaxEncoderTests {
-    public class UrlEncoding {
-      [Fact]
-      public void Encode_Flat_Type() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType));
+namespace YouTrackSharp.Tests.Internal
+{
+    [UsedImplicitly]
+    public class FieldSyntaxEncoderTests
+    {
+        public class UrlEncoding
+        {
+            [Fact]
+            public void Encode_Flat_Type()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType));
 
-        string expected = "id,name,description";
+                string expected = "id,name,description";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Flat_Type_Non_Verbose() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
+            [Fact]
+            public void Encode_Flat_Type_Non_Verbose()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
 
-        string expected = "id,name";
+                string expected = "id,name";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Single_Nested_Types() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.NestedTypes));
+            [Fact]
+            public void Encode_Single_Nested_Types()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.NestedTypes));
 
-        string expected = "id,name,info(id,address,phoneNumber)";
+                string expected = "id,name,info(id,address,phoneNumber)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Deep_Nested_Types() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes));
+            [Fact]
+            public void Encode_Deep_Nested_Types()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes));
 
-        string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
+                string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_With_Inheritance_Merges_Common_Field_Info() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithInheritance));
+            [Fact]
+            public void Encode_Nested_Types_With_Inheritance_Merges_Common_Field_Info()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithInheritance));
 
-        string expected = "id,name,contact(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
+                string expected = "id,name,contact(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_With_Collection() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithCollection));
+            [Fact]
+            public void Encode_Nested_Types_With_Collection()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypesWithCollection));
 
-        string expected = "id,name,contacts(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
+                string expected = "id,name,contacts(id,fullName,info(id,address,phoneNumber),firstName,lastName)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_Max_Depth_0() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 0);
+            [Fact]
+            public void Encode_Nested_Types_Max_Depth_0()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 0);
 
-        string expected = string.Empty;
+                string expected = string.Empty;
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_Max_Depth_1() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 1);
+            [Fact]
+            public void Encode_Nested_Types_Max_Depth_1()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 1);
 
-        string expected = "id,name,contact";
+                string expected = "id,name,contact";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_Max_Depth_2() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 2);
+            [Fact]
+            public void Encode_Nested_Types_Max_Depth_2()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 2);
 
-        string expected = "id,name,contact(firstName,lastName,info,id)";
+                string expected = "id,name,contact(firstName,lastName,info,id)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Types_Max_Depth_3() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 3);
+            [Fact]
+            public void Encode_Nested_Types_Max_Depth_3()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), true, 3);
 
-        string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
+                string expected = "id,name,contact(firstName,lastName,info(id,address,phoneNumber),id)";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Flat_Type_Not_Verbose() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
+            [Fact]
+            public void Encode_Flat_Type_Not_Verbose()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.FlatType), false);
 
-        string expected = "id,name";
+                string expected = "id,name";
 
-        Assert.Equal(expected, encoded);
-      }
+                Assert.Equal(expected, encoded);
+            }
 
-      [Fact]
-      public void Encode_Nested_Type_Not_Verbose() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), false);
+            [Fact]
+            public void Encode_Nested_Type_Not_Verbose()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.DeepNestedTypes), false);
 
-        string expected = "id,contact(firstName,lastName,id)";
+                string expected = "id,contact(firstName,lastName,id)";
 
-        Assert.Equal(expected, encoded);
-      }
-     
-      [Fact]
-      public void Control_Cyclic_References_With_Max_Depth() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), true, 3);
+                Assert.Equal(expected, encoded);
+            }
 
-        string expected = "id,name,cyclic(id,name,cyclic(id,name,cyclic))";
+            [Fact]
+            public void Control_Cyclic_References_With_Max_Depth()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), true, 3);
 
-        Assert.Equal(expected, encoded);
-      }
-      
-      [Fact]
-      public void Skip_Cyclic_References_With_Verbose_Disabled() {
-        FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
-        string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), false);
+                string expected = "id,name,cyclic(id,name,cyclic(id,name,cyclic))";
 
-        string expected = "id,name";
+                Assert.Equal(expected, encoded);
+            }
 
-        Assert.Equal(expected, encoded);
-      }
+            [Fact]
+            public void Skip_Cyclic_References_With_Verbose_Disabled()
+            {
+                FieldSyntaxEncoder encoder = new FieldSyntaxEncoder();
+                string encoded = encoder.Encode(typeof(FieldSyntaxEncoderTestFixtures.CyclicReference), false);
+
+                string expected = "id,name";
+
+                Assert.Equal(expected, encoded);
+            }
+        }
     }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
@@ -70,7 +70,19 @@ namespace YouTrackSharp.Tests.Json {
       }
       
       /// <summary>
-      /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name.
+      /// Creates a Json representation of a <see cref="CompoundType"/>, with given id, name, but null child<br/>
+      /// </summary>
+      /// <param name="id">Id</param>
+      /// <param name="name">Name</param>
+      /// <returns>
+      /// Json representation of <see cref="CompoundType"/>, with null child.
+      /// </returns>
+      public string GetJsonForCompoundTypeWithNullField(int id, string name) {
+        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": null, \"$type\": \"CompoundType\" }}";
+      }
+      
+      /// <summary>
+      /// Creates Json representation of <see cref="CompoundTypeWithList"/>, with given id and name.
       /// The <see cref="CompoundTypeWithList.Children"/> is a list made of multiple <see cref="ChildA"/> and
       /// <see cref="ChildB"/> instances, created from the given <see cref="children"/> enumerable.
       /// This enumerable contains a tuple per child to create, with the concrete type to use (<see cref="ChildA"/> or
@@ -93,12 +105,46 @@ namespace YouTrackSharp.Tests.Json {
                $"[{childrenJsonArray}], \"$type\": \"CompoundTypeWithList\" }}";
       }
 
+      /// <summary>
+      /// Creates Json representation of <see cref="ChildA"/> or <see cref="ChildB"/>, depending on the given
+      /// <see cref="Type"/> 
+      /// </summary>
+      /// <param name="concreteType">Concrete type (<see cref="ChildA"/> or <see cref="ChildB"/>)</param>
+      /// <param name="id">Id of child</param>
+      /// <param name="nameOrTitle">Name (for <see cref="ChildA"/>) or Title (for <see cref="ChildB"/>)</param>
+      /// <returns>Json representation of given <see cref="Type"/></returns>
       private string GetJsonForChild(Type concreteType, int id, string nameOrTitle) {
         if (concreteType == typeof(ChildA)) {
           return GetJsonForChildA(id, nameOrTitle);
         }
 
         return GetJsonForChildB(id, nameOrTitle);
+      }
+      
+      /// <summary>
+      /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
+      /// with children field set to <c>null</c>.
+      /// </summary>
+      /// <param name="id">Id</param>
+      /// <param name="name">Name</param>
+      /// <returns>
+      /// Json representation of <see cref="CompoundTypeWithList"/> with <c>null</c> children.
+      /// </returns>
+      public string GetJsonForCompoundTypeWithNullList(int id, string name) {
+        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": null, \"$type\": \"CompoundTypeWithList\" }}";
+      }
+      
+      /// <summary>
+      /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
+      /// with the children field set to an empty array.
+      /// </summary>
+      /// <param name="id">Id</param>
+      /// <param name="name">Name</param>
+      /// <returns>
+      /// Json representation of <see cref="CompoundTypeWithList"/> with empty children array.
+      /// </returns>
+      public string GetJsonForCompoundTypeWithEmptyList(int id, string name) {
+        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": [], \"$type\": \"CompoundTypeWithList\" }}";
       }
     }
     

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using YouTrackSharp.Json;
+using YouTrackSharp.SerializationAttributes;
+
+namespace YouTrackSharp.Tests.Json {
+  [UsedImplicitly]
+  public class KnownTypeConverterTestFixtures {
+    public class Json {
+      public string GetJsonForChildA(int id, string name) {
+        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"$type\": \"ChildA\" }}";
+      }
+
+      public string GetJsonForChildB(int id, string title) {
+        return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"ChildB\" }}";
+      }
+
+      public string GetJsonForUnknownType(int id, string title) {
+        return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"UnknownType\" }}";
+      }
+
+      public string GetJsonForUnspecifiedType(int id, string title) {
+        return $"{{ \"id\": {id}, \"title\": \"{title}\" }}";
+      }
+
+      public string GetJsonForCompoundType(int id, string name, int childId, string childName) {
+        string childJson = GetJsonForChildA(childId, childName);
+
+        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": {childJson}, \"$type\": \"CompoundType\" }}";
+      }
+    }
+
+    public class CompoundType {
+      [JsonProperty("id")]
+      public int Id { get; set; }
+
+      [JsonProperty("name")]
+      public string Name { get; set; }
+
+      [JsonProperty("child")]
+      [JsonConverter(typeof(KnownTypeConverter<BaseType>))]
+      public BaseType Child { get; set; }
+    }
+
+    [KnownType(typeof(ChildA))]
+    [KnownType(typeof(ChildB))]
+    public class BaseType {
+      [JsonProperty("id")]
+      public int Id { get; set; }
+    }
+
+    public class ChildA : BaseType {
+      [JsonProperty("name")]
+      public string Name { get; set; }
+    }
+
+    public class ChildB : BaseType {
+      [JsonProperty("title")]
+      public string Title { get; set; }
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTestFixtures.cs
@@ -6,187 +6,209 @@ using Newtonsoft.Json;
 using YouTrackSharp.Json;
 using YouTrackSharp.SerializationAttributes;
 
-namespace YouTrackSharp.Tests.Json {
-  [UsedImplicitly]
-  public class KnownTypeConverterTestFixtures {
-    public class Json {
-      /// <summary>
-      /// Creates a Json string representation of a <see cref="ChildA"/> instance, with given id and name.
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <returns>Json representation of <see cref="ChildA"/> with given id and name</returns>
-      public string GetJsonForChildA(int id, string name) {
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"$type\": \"ChildA\" }}";
-      }
+namespace YouTrackSharp.Tests.Json
+{
+    [UsedImplicitly]
+    public class KnownTypeConverterTestFixtures
+    {
+        public class Json
+        {
+            /// <summary>
+            /// Creates a Json string representation of a <see cref="ChildA"/> instance, with given id and name.
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <returns>Json representation of <see cref="ChildA"/> with given id and name</returns>
+            public string GetJsonForChildA(int id, string name)
+            {
+                return $"{{ \"id\": {id}, \"name\": \"{name}\", \"$type\": \"ChildA\" }}";
+            }
 
-      /// <summary>
-      /// Creates a Json string representation of a <see cref="ChildB"/> instance, with given id and title.
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="title">Title</param>
-      /// <returns>Json representation of <see cref="ChildB"/> with given id and title</returns>
-      public string GetJsonForChildB(int id, string title) {
-        return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"ChildB\" }}";
-      }
+            /// <summary>
+            /// Creates a Json string representation of a <see cref="ChildB"/> instance, with given id and title.
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="title">Title</param>
+            /// <returns>Json representation of <see cref="ChildB"/> with given id and title</returns>
+            public string GetJsonForChildB(int id, string title)
+            {
+                return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"ChildB\" }}";
+            }
 
-      /// <summary>
-      /// Creates a Json string representation of an unknown sub-type of <see cref="BaseType"/> (unknown to
-      /// serialization), with given id and title.
-      /// </summary>
-      /// <param name="id">Id of object</param>
-      /// <param name="title">Title of object</param>
-      /// <returns>Json representation of an unknown sub-type of <see cref="BaseType"/></returns>
-      public string GetJsonForUnknownType(int id, string title) {
-        return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"UnknownType\" }}";
-      }
+            /// <summary>
+            /// Creates a Json string representation of an unknown sub-type of <see cref="BaseType"/> (unknown to
+            /// serialization), with given id and title.
+            /// </summary>
+            /// <param name="id">Id of object</param>
+            /// <param name="title">Title of object</param>
+            /// <returns>Json representation of an unknown sub-type of <see cref="BaseType"/></returns>
+            public string GetJsonForUnknownType(int id, string title)
+            {
+                return $"{{ \"id\": {id}, \"title\": \"{title}\", \"$type\": \"UnknownType\" }}";
+            }
 
-      /// <summary>
-      /// Creates a Json string representation of an object, with no "$type" field, with given id and title. 
-      /// </summary>
-      /// <param name="id">Id of object</param>
-      /// <param name="title">Title of object</param>
-      /// <returns>Json representation of an untyped object</returns>
-      public string GetJsonForUnspecifiedType(int id, string title) {
-        return $"{{ \"id\": {id}, \"title\": \"{title}\" }}";
-      }
+            /// <summary>
+            /// Creates a Json string representation of an object, with no "$type" field, with given id and title. 
+            /// </summary>
+            /// <param name="id">Id of object</param>
+            /// <param name="title">Title of object</param>
+            /// <returns>Json representation of an untyped object</returns>
+            public string GetJsonForUnspecifiedType(int id, string title)
+            {
+                return $"{{ \"id\": {id}, \"title\": \"{title}\" }}";
+            }
 
-      /// <summary>
-      /// Creates a Json representation of a <see cref="CompoundType"/>, with given id, name.<br/>
-      /// The <see cref="CompoundType.Child"/> instance is a json representation of  concrete type <see cref="ChildA"/>,
-      /// with given child id and child name.
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <param name="childId">Id of child</param>
-      /// <param name="childName">Name of child</param>
-      /// <returns>
-      /// Json representation of <see cref="CompoundType"/>, with <see cref="ChildA"/> instance variable.
-      /// </returns>
-      public string GetJsonForCompoundType(int id, string name, int childId, string childName) {
-        string childJson = GetJsonForChildA(childId, childName);
+            /// <summary>
+            /// Creates a Json representation of a <see cref="CompoundType"/>, with given id, name.<br/>
+            /// The <see cref="CompoundType.Child"/> instance is a json representation of  concrete type <see cref="ChildA"/>,
+            /// with given child id and child name.
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <param name="childId">Id of child</param>
+            /// <param name="childName">Name of child</param>
+            /// <returns>
+            /// Json representation of <see cref="CompoundType"/>, with <see cref="ChildA"/> instance variable.
+            /// </returns>
+            public string GetJsonForCompoundType(int id, string name, int childId, string childName)
+            {
+                string childJson = GetJsonForChildA(childId, childName);
 
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": {childJson}, \"$type\": \"CompoundType\" }}";
-      }
-      
-      /// <summary>
-      /// Creates a Json representation of a <see cref="CompoundType"/>, with given id, name, but null child<br/>
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <returns>
-      /// Json representation of <see cref="CompoundType"/>, with null child.
-      /// </returns>
-      public string GetJsonForCompoundTypeWithNullField(int id, string name) {
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": null, \"$type\": \"CompoundType\" }}";
-      }
-      
-      /// <summary>
-      /// Creates Json representation of <see cref="CompoundTypeWithList"/>, with given id and name.
-      /// The <see cref="CompoundTypeWithList.Children"/> is a list made of multiple <see cref="ChildA"/> and
-      /// <see cref="ChildB"/> instances, created from the given <see cref="children"/> enumerable.
-      /// This enumerable contains a tuple per child to create, with the concrete type to use (<see cref="ChildA"/> or
-      /// <see cref="ChildB"/>, the child id and its name).
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <param name="children">Children specifications</param>
-      /// <returns>
-      /// Json representation of <see cref="CompoundTypeWithList"/>, with array of children of types
-      /// <see cref="ChildA"/> or <see cref="ChildB"/>.
-      /// </returns>
-      public string GetJsonForCompoundTypeWithList(int id, string name, IEnumerable<Tuple<Type, int, string>> children) {
-        IEnumerable<string> childrenJson =
-          children.Select(child => GetJsonForChild(child.Item1, child.Item2, child.Item3));
+                return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": {childJson}, \"$type\": \"CompoundType\" }}";
+            }
 
-        string childrenJsonArray = string.Join(", ", childrenJson);
+            /// <summary>
+            /// Creates a Json representation of a <see cref="CompoundType"/>, with given id, name, but null child<br/>
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <returns>
+            /// Json representation of <see cref="CompoundType"/>, with null child.
+            /// </returns>
+            public string GetJsonForCompoundTypeWithNullField(int id, string name)
+            {
+                return $"{{ \"id\": {id}, \"name\": \"{name}\", \"child\": null, \"$type\": \"CompoundType\" }}";
+            }
 
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": " +
-               $"[{childrenJsonArray}], \"$type\": \"CompoundTypeWithList\" }}";
-      }
+            /// <summary>
+            /// Creates Json representation of <see cref="CompoundTypeWithList"/>, with given id and name.
+            /// The <see cref="CompoundTypeWithList.Children"/> is a list made of multiple <see cref="ChildA"/> and
+            /// <see cref="ChildB"/> instances, created from the given <see cref="children"/> enumerable.
+            /// This enumerable contains a tuple per child to create, with the concrete type to use (<see cref="ChildA"/> or
+            /// <see cref="ChildB"/>, the child id and its name).
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <param name="children">Children specifications</param>
+            /// <returns>
+            /// Json representation of <see cref="CompoundTypeWithList"/>, with array of children of types
+            /// <see cref="ChildA"/> or <see cref="ChildB"/>.
+            /// </returns>
+            public string GetJsonForCompoundTypeWithList(int id, string name,
+                                                         IEnumerable<Tuple<Type, int, string>> children)
+            {
+                IEnumerable<string> childrenJson =
+                    children.Select(child => GetJsonForChild(child.Item1, child.Item2, child.Item3));
 
-      /// <summary>
-      /// Creates Json representation of <see cref="ChildA"/> or <see cref="ChildB"/>, depending on the given
-      /// <see cref="Type"/> 
-      /// </summary>
-      /// <param name="concreteType">Concrete type (<see cref="ChildA"/> or <see cref="ChildB"/>)</param>
-      /// <param name="id">Id of child</param>
-      /// <param name="nameOrTitle">Name (for <see cref="ChildA"/>) or Title (for <see cref="ChildB"/>)</param>
-      /// <returns>Json representation of given <see cref="Type"/></returns>
-      private string GetJsonForChild(Type concreteType, int id, string nameOrTitle) {
-        if (concreteType == typeof(ChildA)) {
-          return GetJsonForChildA(id, nameOrTitle);
+                string childrenJsonArray = string.Join(", ", childrenJson);
+
+                return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": " +
+                       $"[{childrenJsonArray}], \"$type\": \"CompoundTypeWithList\" }}";
+            }
+
+            /// <summary>
+            /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
+            /// with children field set to <c>null</c>.
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <returns>
+            /// Json representation of <see cref="CompoundTypeWithList"/> with <c>null</c> children.
+            /// </returns>
+            public string GetJsonForCompoundTypeWithNullList(int id, string name)
+            {
+                return
+                    $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": null, \"$type\": \"CompoundTypeWithList\" }}";
+            }
+
+            /// <summary>
+            /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
+            /// with the children field set to an empty array.
+            /// </summary>
+            /// <param name="id">Id</param>
+            /// <param name="name">Name</param>
+            /// <returns>
+            /// Json representation of <see cref="CompoundTypeWithList"/> with empty children array.
+            /// </returns>
+            public string GetJsonForCompoundTypeWithEmptyList(int id, string name)
+            {
+                return
+                    $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": [], \"$type\": \"CompoundTypeWithList\" }}";
+            }
+
+            /// <summary>
+            /// Creates Json representation of <see cref="ChildA"/> or <see cref="ChildB"/>, depending on the given
+            /// <see cref="Type"/> 
+            /// </summary>
+            /// <param name="concreteType">Concrete type (<see cref="ChildA"/> or <see cref="ChildB"/>)</param>
+            /// <param name="id">Id of child</param>
+            /// <param name="nameOrTitle">Name (for <see cref="ChildA"/>) or Title (for <see cref="ChildB"/>)</param>
+            /// <returns>Json representation of given <see cref="Type"/></returns>
+            private string GetJsonForChild(Type concreteType, int id, string nameOrTitle)
+            {
+                if (concreteType == typeof(ChildA))
+                {
+                    return GetJsonForChildA(id, nameOrTitle);
+                }
+
+                return GetJsonForChildB(id, nameOrTitle);
+            }
         }
 
-        return GetJsonForChildB(id, nameOrTitle);
-      }
-      
-      /// <summary>
-      /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
-      /// with children field set to <c>null</c>.
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <returns>
-      /// Json representation of <see cref="CompoundTypeWithList"/> with <c>null</c> children.
-      /// </returns>
-      public string GetJsonForCompoundTypeWithNullList(int id, string name) {
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": null, \"$type\": \"CompoundTypeWithList\" }}";
-      }
-      
-      /// <summary>
-      /// Creates json representation of <see cref="CompoundTypeWithList"/>, with given id and name, but
-      /// with the children field set to an empty array.
-      /// </summary>
-      /// <param name="id">Id</param>
-      /// <param name="name">Name</param>
-      /// <returns>
-      /// Json representation of <see cref="CompoundTypeWithList"/> with empty children array.
-      /// </returns>
-      public string GetJsonForCompoundTypeWithEmptyList(int id, string name) {
-        return $"{{ \"id\": {id}, \"name\": \"{name}\", \"children\": [], \"$type\": \"CompoundTypeWithList\" }}";
-      }
+        public class CompoundTypeWithList
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("children")]
+            [JsonConverter(typeof(KnownTypeListConverter<BaseType>))]
+            public List<BaseType> Children { get; set; }
+        }
+
+        public class CompoundType
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("child")]
+            [JsonConverter(typeof(KnownTypeConverter<BaseType>))]
+            public BaseType Child { get; set; }
+        }
+
+        [KnownType(typeof(ChildA))]
+        [KnownType(typeof(ChildB))]
+        public class BaseType
+        {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+        }
+
+        public class ChildA : BaseType
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+        }
+
+        public class ChildB : BaseType
+        {
+            [JsonProperty("title")]
+            public string Title { get; set; }
+        }
     }
-    
-    public class CompoundTypeWithList {
-      [JsonProperty("id")]
-      public int Id { get; set; }
-
-      [JsonProperty("name")]
-      public string Name { get; set; }
-
-      [JsonProperty("children")]
-      [JsonConverter(typeof(KnownTypeListConverter<BaseType>))]
-      public List<BaseType> Children { get; set; }
-    }
-
-    public class CompoundType {
-      [JsonProperty("id")]
-      public int Id { get; set; }
-
-      [JsonProperty("name")]
-      public string Name { get; set; }
-
-      [JsonProperty("child")]
-      [JsonConverter(typeof(KnownTypeConverter<BaseType>))]
-      public BaseType Child { get; set; }
-    }
-
-    [KnownType(typeof(ChildA))]
-    [KnownType(typeof(ChildB))]
-    public class BaseType {
-      [JsonProperty("id")]
-      public int Id { get; set; }
-    }
-
-    public class ChildA : BaseType {
-      [JsonProperty("name")]
-      public string Name { get; set; }
-    }
-
-    public class ChildB : BaseType {
-      [JsonProperty("title")]
-      public string Title { get; set; }
-    }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
@@ -1,0 +1,123 @@
+using System.IO;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Xunit;
+using YouTrackSharp.Json;
+using Fixtures = YouTrackSharp.Tests.Json.KnownTypeConverterTestFixtures;
+
+namespace YouTrackSharp.Tests.Json {
+  [UsedImplicitly]
+  public class KnownTypeConverterTests {
+    public class ReadJson {
+      [Fact]
+      public void Identifies_Correct_Subtype_ChildTypeA() {
+        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+        Fixtures.Json fixtures = new Fixtures.Json();
+
+        string expectedName = "Example Name";
+        int expectedId = 123;
+
+        using JsonTextReader reader =
+          new JsonTextReader(new StringReader(fixtures.GetJsonForChildA(expectedId, expectedName)));
+        reader.Read();
+
+        // Act
+        Fixtures.ChildA result =
+          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                             new JsonSerializer()) as Fixtures.ChildA;
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+      }
+
+      [Fact]
+      public void Identifies_Correct_Subtype_ChildTypeB() {
+        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+        Fixtures.Json fixtures = new Fixtures.Json();
+
+        string expectedTitle = "Example Title";
+        int expectedId = 123;
+
+        using JsonTextReader reader =
+          new JsonTextReader(new StringReader(fixtures.GetJsonForChildB(expectedId, expectedTitle)));
+        reader.Read();
+
+        // Act
+        Fixtures.ChildB result =
+          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                             new JsonSerializer()) as Fixtures.ChildB;
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedTitle, result.Title);
+      }
+
+      [Fact]
+      public void Unknown_Subtype_Defaults_To_BaseType() {
+        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+        Fixtures.Json fixtures = new Fixtures.Json();
+
+        string expectedTitle = "Example Title";
+        int expectedId = 123;
+
+        using JsonTextReader reader =
+          new JsonTextReader(new StringReader(fixtures.GetJsonForUnknownType(expectedId, expectedTitle)));
+        reader.Read();
+
+        // Act
+        Fixtures.BaseType result =
+          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                             new JsonSerializer()) as Fixtures.BaseType;
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+      }
+      
+      [Fact]
+      public void Unspecified_Type_Defaults_To_BaseType() {
+        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+        Fixtures.Json fixtures = new Fixtures.Json();
+
+        string expectedTitle = "Example Title";
+        int expectedId = 123;
+
+        using JsonTextReader reader =
+          new JsonTextReader(new StringReader(fixtures.GetJsonForUnspecifiedType(expectedId, expectedTitle)));
+        reader.Read();
+
+        // Act
+        Fixtures.BaseType result =
+          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                             new JsonSerializer()) as Fixtures.BaseType;
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+      }
+      
+      [Fact]
+      public void Deserialize_Type_With_Polymorphic_Field() {
+        string expectedName = "Example Name";
+        int expectedId = 123;
+        
+        string expectedChildName = "Child Name";
+        int expectedChildId = 456;
+
+        Fixtures.Json fixtures = new Fixtures.Json();
+        string json = fixtures.GetJsonForCompoundType(expectedId, expectedName, expectedChildId, expectedChildName);
+        
+        Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
+        
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+
+        Fixtures.ChildA child = result.Child as Fixtures.ChildA;
+        Assert.NotNull(child);
+        Assert.Equal(expectedChildId, child.Id);
+        Assert.Equal(expectedChildName, child.Name);
+      }
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
@@ -5,138 +5,148 @@ using Xunit;
 using YouTrackSharp.Json;
 using Fixtures = YouTrackSharp.Tests.Json.KnownTypeConverterTestFixtures;
 
-namespace YouTrackSharp.Tests.Json {
-  [UsedImplicitly]
-  public class KnownTypeConverterTests {
-    public class ReadJson {
-      [Fact]
-      public void Identifies_Correct_Subtype_ChildTypeA() {
-        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
-        Fixtures.Json fixtures = new Fixtures.Json();
+namespace YouTrackSharp.Tests.Json
+{
+    [UsedImplicitly]
+    public class KnownTypeConverterTests
+    {
+        public class ReadJson
+        {
+            [Fact]
+            public void Identifies_Correct_Subtype_ChildTypeA()
+            {
+                KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+                Fixtures.Json fixtures = new Fixtures.Json();
 
-        string expectedName = "Example Name";
-        int expectedId = 123;
+                string expectedName = "Example Name";
+                int expectedId = 123;
 
-        using JsonTextReader reader =
-          new JsonTextReader(new StringReader(fixtures.GetJsonForChildA(expectedId, expectedName)));
-        reader.Read();
+                using JsonTextReader reader =
+                    new JsonTextReader(new StringReader(fixtures.GetJsonForChildA(expectedId, expectedName)));
+                reader.Read();
 
-        // Act
-        Fixtures.ChildA result =
-          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
-                             new JsonSerializer()) as Fixtures.ChildA;
+                // Act
+                Fixtures.ChildA result =
+                    converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                                       new JsonSerializer()) as Fixtures.ChildA;
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
-      }
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+            }
 
-      [Fact]
-      public void Identifies_Correct_Subtype_ChildTypeB() {
-        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
-        Fixtures.Json fixtures = new Fixtures.Json();
+            [Fact]
+            public void Identifies_Correct_Subtype_ChildTypeB()
+            {
+                KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+                Fixtures.Json fixtures = new Fixtures.Json();
 
-        string expectedTitle = "Example Title";
-        int expectedId = 123;
+                string expectedTitle = "Example Title";
+                int expectedId = 123;
 
-        using JsonTextReader reader =
-          new JsonTextReader(new StringReader(fixtures.GetJsonForChildB(expectedId, expectedTitle)));
-        reader.Read();
+                using JsonTextReader reader =
+                    new JsonTextReader(new StringReader(fixtures.GetJsonForChildB(expectedId, expectedTitle)));
+                reader.Read();
 
-        // Act
-        Fixtures.ChildB result =
-          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
-                             new JsonSerializer()) as Fixtures.ChildB;
+                // Act
+                Fixtures.ChildB result =
+                    converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
+                                       new JsonSerializer()) as Fixtures.ChildB;
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedTitle, result.Title);
-      }
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedTitle, result.Title);
+            }
 
-      [Fact]
-      public void Unknown_Subtype_Defaults_To_BaseType() {
-        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
-        Fixtures.Json fixtures = new Fixtures.Json();
+            [Fact]
+            public void Unknown_Subtype_Defaults_To_BaseType()
+            {
+                KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+                Fixtures.Json fixtures = new Fixtures.Json();
 
-        string expectedTitle = "Example Title";
-        int expectedId = 123;
+                string expectedTitle = "Example Title";
+                int expectedId = 123;
 
-        using JsonTextReader reader =
-          new JsonTextReader(new StringReader(fixtures.GetJsonForUnknownType(expectedId, expectedTitle)));
-        reader.Read();
+                using JsonTextReader reader =
+                    new JsonTextReader(new StringReader(fixtures.GetJsonForUnknownType(expectedId, expectedTitle)));
+                reader.Read();
 
-        // Act
-        Fixtures.BaseType result =
-          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
-                             new JsonSerializer()) as Fixtures.BaseType;
+                // Act
+                Fixtures.BaseType result =
+                    converter.ReadJson(reader, typeof(Fixtures.BaseType), null, new JsonSerializer()) as
+                        Fixtures.BaseType;
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-      }
-      
-      [Fact]
-      public void Unspecified_Type_Defaults_To_BaseType() {
-        KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
-        Fixtures.Json fixtures = new Fixtures.Json();
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+            }
 
-        string expectedTitle = "Example Title";
-        int expectedId = 123;
+            [Fact]
+            public void Unspecified_Type_Defaults_To_BaseType()
+            {
+                KnownTypeConverter<Fixtures.BaseType> converter = new KnownTypeConverter<Fixtures.BaseType>();
+                Fixtures.Json fixtures = new Fixtures.Json();
 
-        using JsonTextReader reader =
-          new JsonTextReader(new StringReader(fixtures.GetJsonForUnspecifiedType(expectedId, expectedTitle)));
-        reader.Read();
+                string expectedTitle = "Example Title";
+                int expectedId = 123;
 
-        // Act
-        Fixtures.BaseType result =
-          converter.ReadJson(reader, typeof(Fixtures.BaseType), null,
-                             new JsonSerializer()) as Fixtures.BaseType;
+                using JsonTextReader reader =
+                    new JsonTextReader(new StringReader(fixtures.GetJsonForUnspecifiedType(expectedId, expectedTitle)));
+                reader.Read();
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-      }
-      
-      [Fact]
-      public void Deserialize_Type_With_Polymorphic_Field() {
-        string expectedName = "Example Name";
-        int expectedId = 123;
-        
-        string expectedChildName = "Child Name";
-        int expectedChildId = 456;
+                // Act
+                Fixtures.BaseType result =
+                    converter.ReadJson(reader, typeof(Fixtures.BaseType), null, new JsonSerializer()) as
+                        Fixtures.BaseType;
 
-        Fixtures.Json fixtures = new Fixtures.Json();
-        string json = fixtures.GetJsonForCompoundType(expectedId, expectedName, expectedChildId, expectedChildName);
-        
-        Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
-        
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+            }
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
+            [Fact]
+            public void Deserialize_Type_With_Polymorphic_Field()
+            {
+                string expectedName = "Example Name";
+                int expectedId = 123;
 
-        Fixtures.ChildA child = result.Child as Fixtures.ChildA;
-        Assert.NotNull(child);
-        Assert.Equal(expectedChildId, child.Id);
-        Assert.Equal(expectedChildName, child.Name);
-      }
-      
-      [Fact]
-      public void Deserialize_Type_With_Null_Polymorphic_Field() {
-        string expectedName = "Example Name";
-        int expectedId = 123;
-        
-        Fixtures.Json fixtures = new Fixtures.Json();
-        string json = fixtures.GetJsonForCompoundTypeWithNullField(expectedId, expectedName);
-        
-        Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
-        
+                string expectedChildName = "Child Name";
+                int expectedChildId = 456;
 
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
+                Fixtures.Json fixtures = new Fixtures.Json();
+                string json =
+                    fixtures.GetJsonForCompoundType(expectedId, expectedName, expectedChildId, expectedChildName);
 
-        Fixtures.ChildA child = result.Child as Fixtures.ChildA;
-        Assert.Null(child);
-      }
+                Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
+
+
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+
+                Fixtures.ChildA child = result.Child as Fixtures.ChildA;
+                Assert.NotNull(child);
+                Assert.Equal(expectedChildId, child.Id);
+                Assert.Equal(expectedChildName, child.Name);
+            }
+
+            [Fact]
+            public void Deserialize_Type_With_Null_Polymorphic_Field()
+            {
+                string expectedName = "Example Name";
+                int expectedId = 123;
+
+                Fixtures.Json fixtures = new Fixtures.Json();
+                string json = fixtures.GetJsonForCompoundTypeWithNullField(expectedId, expectedName);
+
+                Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
+
+
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+
+                Fixtures.ChildA child = result.Child as Fixtures.ChildA;
+                Assert.Null(child);
+            }
+        }
     }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeConverterTests.cs
@@ -118,6 +118,25 @@ namespace YouTrackSharp.Tests.Json {
         Assert.Equal(expectedChildId, child.Id);
         Assert.Equal(expectedChildName, child.Name);
       }
+      
+      [Fact]
+      public void Deserialize_Type_With_Null_Polymorphic_Field() {
+        string expectedName = "Example Name";
+        int expectedId = 123;
+        
+        Fixtures.Json fixtures = new Fixtures.Json();
+        string json = fixtures.GetJsonForCompoundTypeWithNullField(expectedId, expectedName);
+        
+        Fixtures.CompoundType result = JsonConvert.DeserializeObject<Fixtures.CompoundType>(json);
+        
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+
+        Fixtures.ChildA child = result.Child as Fixtures.ChildA;
+        Assert.Null(child);
+      }
     }
   }
 }

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Xunit;
+using Fixtures = YouTrackSharp.Tests.Json.KnownTypeConverterTestFixtures;
+
+namespace YouTrackSharp.Tests.Json {
+  [UsedImplicitly]
+  public class KnownTypeListConverterTests {
+    public class ReadJson {
+      [Fact]
+      public void Deserialize_Type_With_Polymorphic_Collection() {
+        string expectedName = "Example Name";
+        int expectedId = 123;
+
+        IList<Tuple<Type, int, string>> expectedChildren = new List<Tuple<Type, int, string>>();
+        
+        for (int i = 0; i < 10; i++) {
+          Type type = i % 2 == 0 ? typeof(Fixtures.ChildA) : typeof(Fixtures.ChildB);
+          expectedChildren.Add(new Tuple<Type, int, string>(type, i, $"Child {i}"));
+        }
+
+        Fixtures.Json fixtures = new Fixtures.Json();
+        string json = fixtures.GetJsonForCompoundTypeWithList(expectedId, expectedName, expectedChildren);
+
+        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+
+        Assert.NotNull(result.Children);
+        foreach (Fixtures.BaseType child in result.Children) {
+          int id = child.Id;
+          Tuple<Type,int,string> expectedChild = expectedChildren.FirstOrDefault(c => c.Item2 == id);
+
+          Assert.NotNull(expectedChild);
+
+          Assert.Equal(expectedChild.Item1, child.GetType());
+
+          switch (child) {
+            case Fixtures.ChildA childA:
+              Assert.Equal(expectedChild.Item3, childA.Name);
+              break;
+            
+            case Fixtures.ChildB childB:
+              Assert.Equal(expectedChild.Item3, childB.Title);
+              break;
+            
+            default:
+              Assert.True(false, "Child was not deserialized to recognizable type");
+              break;
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
@@ -6,89 +6,101 @@ using Newtonsoft.Json;
 using Xunit;
 using Fixtures = YouTrackSharp.Tests.Json.KnownTypeConverterTestFixtures;
 
-namespace YouTrackSharp.Tests.Json {
-  [UsedImplicitly]
-  public class KnownTypeListConverterTests {
-    public class ReadJson {
-      [Fact]
-      public void Deserialize_Type_With_Polymorphic_Collection() {
-        string expectedName = "Example Name";
-        int expectedId = 123;
+namespace YouTrackSharp.Tests.Json
+{
+    [UsedImplicitly]
+    public class KnownTypeListConverterTests
+    {
+        public class ReadJson
+        {
+            [Fact]
+            public void Deserialize_Type_With_Polymorphic_Collection()
+            {
+                string expectedName = "Example Name";
+                int expectedId = 123;
 
-        IList<Tuple<Type, int, string>> expectedChildren = new List<Tuple<Type, int, string>>();
-        
-        for (int i = 0; i < 10; i++) {
-          Type type = i % 2 == 0 ? typeof(Fixtures.ChildA) : typeof(Fixtures.ChildB);
-          expectedChildren.Add(new Tuple<Type, int, string>(type, i, $"Child {i}"));
+                IList<Tuple<Type, int, string>> expectedChildren = new List<Tuple<Type, int, string>>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    Type type = i % 2 == 0 ? typeof(Fixtures.ChildA) : typeof(Fixtures.ChildB);
+                    expectedChildren.Add(new Tuple<Type, int, string>(type, i, $"Child {i}"));
+                }
+
+                Fixtures.Json fixtures = new Fixtures.Json();
+                string json = fixtures.GetJsonForCompoundTypeWithList(expectedId, expectedName, expectedChildren);
+
+                Fixtures.CompoundTypeWithList result =
+                    JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+
+                Assert.NotNull(result.Children);
+                foreach (Fixtures.BaseType child in result.Children)
+                {
+                    int id = child.Id;
+                    Tuple<Type, int, string> expectedChild = expectedChildren.FirstOrDefault(c => c.Item2 == id);
+
+                    Assert.NotNull(expectedChild);
+
+                    Assert.Equal(expectedChild.Item1, child.GetType());
+
+                    switch (child)
+                    {
+                        case Fixtures.ChildA childA:
+                            Assert.Equal(expectedChild.Item3, childA.Name);
+                            break;
+
+                        case Fixtures.ChildB childB:
+                            Assert.Equal(expectedChild.Item3, childB.Title);
+                            break;
+
+                        default:
+                            Assert.True(false, "Child was not deserialized to recognizable type");
+                            break;
+                    }
+                }
+            }
+
+            [Fact]
+            public void Deserialize_Type_With_Polymorphic_Collection_Null()
+            {
+                string expectedName = "Example Name";
+                int expectedId = 123;
+
+                Fixtures.Json fixtures = new Fixtures.Json();
+                string json = fixtures.GetJsonForCompoundTypeWithNullList(expectedId, expectedName);
+
+                Fixtures.CompoundTypeWithList result =
+                    JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+
+                Assert.Null(result.Children);
+            }
+
+            [Fact]
+            public void Deserialize_Type_With_Polymorphic_Collection_Empty()
+            {
+                string expectedName = "Example Name";
+                int expectedId = 123;
+
+                Fixtures.Json fixtures = new Fixtures.Json();
+                string json = fixtures.GetJsonForCompoundTypeWithEmptyList(expectedId, expectedName);
+
+                Fixtures.CompoundTypeWithList result =
+                    JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+                Assert.NotNull(result);
+                Assert.Equal(expectedId, result.Id);
+                Assert.Equal(expectedName, result.Name);
+                Assert.NotNull(result.Children);
+                Assert.Empty(result.Children);
+            }
         }
-
-        Fixtures.Json fixtures = new Fixtures.Json();
-        string json = fixtures.GetJsonForCompoundTypeWithList(expectedId, expectedName, expectedChildren);
-
-        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
-
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
-
-        Assert.NotNull(result.Children);
-        foreach (Fixtures.BaseType child in result.Children) {
-          int id = child.Id;
-          Tuple<Type,int,string> expectedChild = expectedChildren.FirstOrDefault(c => c.Item2 == id);
-
-          Assert.NotNull(expectedChild);
-
-          Assert.Equal(expectedChild.Item1, child.GetType());
-
-          switch (child) {
-            case Fixtures.ChildA childA:
-              Assert.Equal(expectedChild.Item3, childA.Name);
-              break;
-            
-            case Fixtures.ChildB childB:
-              Assert.Equal(expectedChild.Item3, childB.Title);
-              break;
-            
-            default:
-              Assert.True(false, "Child was not deserialized to recognizable type");
-              break;
-          }
-        }
-      }
-      
-      [Fact]
-      public void Deserialize_Type_With_Polymorphic_Collection_Null() {
-        string expectedName = "Example Name";
-        int expectedId = 123;
-
-        Fixtures.Json fixtures = new Fixtures.Json();
-        string json = fixtures.GetJsonForCompoundTypeWithNullList(expectedId, expectedName);
-
-        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
-
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
-
-        Assert.Null(result.Children);
-      }
-      
-      [Fact]
-      public void Deserialize_Type_With_Polymorphic_Collection_Empty() {
-        string expectedName = "Example Name";
-        int expectedId = 123;
-
-        Fixtures.Json fixtures = new Fixtures.Json();
-        string json = fixtures.GetJsonForCompoundTypeWithEmptyList(expectedId, expectedName);
-
-        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
-
-        Assert.NotNull(result);
-        Assert.Equal(expectedId, result.Id);
-        Assert.Equal(expectedName, result.Name);
-        Assert.NotNull(result.Children);
-        Assert.Empty(result.Children);
-      }
     }
-  }
 }

--- a/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
+++ b/tests/YouTrackSharp.Tests/Json/KnownTypeListConverterTests.cs
@@ -55,6 +55,40 @@ namespace YouTrackSharp.Tests.Json {
           }
         }
       }
+      
+      [Fact]
+      public void Deserialize_Type_With_Polymorphic_Collection_Null() {
+        string expectedName = "Example Name";
+        int expectedId = 123;
+
+        Fixtures.Json fixtures = new Fixtures.Json();
+        string json = fixtures.GetJsonForCompoundTypeWithNullList(expectedId, expectedName);
+
+        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+
+        Assert.Null(result.Children);
+      }
+      
+      [Fact]
+      public void Deserialize_Type_With_Polymorphic_Collection_Empty() {
+        string expectedName = "Example Name";
+        int expectedId = 123;
+
+        Fixtures.Json fixtures = new Fixtures.Json();
+        string json = fixtures.GetJsonForCompoundTypeWithEmptyList(expectedId, expectedName);
+
+        Fixtures.CompoundTypeWithList result = JsonConvert.DeserializeObject<Fixtures.CompoundTypeWithList>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedId, result.Id);
+        Assert.Equal(expectedName, result.Name);
+        Assert.NotNull(result.Children);
+        Assert.Empty(result.Children);
+      }
     }
   }
 }

--- a/tests/YouTrackSharp.Tests/Resources/CompleteAgile.json
+++ b/tests/YouTrackSharp.Tests/Resources/CompleteAgile.json
@@ -1,0 +1,202 @@
+[
+  {
+    "projects": [
+      {
+        "shortName": "DP1",
+        "name": "DemoProject1",
+        "id": "0-1",
+        "$type": "Project"
+      }
+    ],
+    "swimlaneSettings": {
+      "field": {
+        "customField": {
+          "name": "Type",
+          "$type": "CustomField"
+        },
+        "presentation": "Type",
+        "id": "51-2",
+        "name": "Type",
+        "$type": "CustomFilterField"
+      },
+      "values": [
+        {
+          "name": "Feature",
+          "id": "Feature",
+          "$type": "SwimlaneValue"
+        }
+      ],
+      "defaultCardType": {
+        "name": "Task",
+        "id": "Task",
+        "$type": "SwimlaneValue"
+      },
+      "id": "105-3",
+      "$type": "IssueBasedSwimlaneSettings"
+    },
+    "estimationField": {
+      "name": "Estimation",
+      "$type": "CustomField"
+    },
+    "sprints": [
+      {
+        "name": "First sprint",
+        "id": "109-2",
+        "$type": "Sprint"
+      }
+    ],
+    "hideOrphansSwimlane": false,
+    "orphansAtTheTop": false,
+    "visibleForProjectBased": true,
+    "updateableByProjectBased": true,
+    "columnSettings": {
+      "field": {
+        "name": "State",
+        "$type": "CustomField"
+      },
+      "columns": [
+        {
+          "fieldValues": [
+            {
+              "name": "Open",
+              "isResolved": false,
+              "id": "111-12",
+              "$type": "AgileColumnFieldValue"
+            }
+          ],
+          "ordinal": 0,
+          "presentation": "Open",
+          "wipLimit": null,
+          "isResolved": false,
+          "id": "110-8",
+          "$type": "AgileColumn"
+        },
+        {
+          "fieldValues": [
+            {
+              "name": "In Progress",
+              "isResolved": false,
+              "id": "111-13",
+              "$type": "AgileColumnFieldValue"
+            }
+          ],
+          "ordinal": 1,
+          "presentation": "In Progress",
+          "wipLimit": null,
+          "isResolved": false,
+          "id": "110-9",
+          "$type": "AgileColumn"
+        },
+        {
+          "fieldValues": [
+            {
+              "name": "Fixed",
+              "isResolved": true,
+              "id": "111-14",
+              "$type": "AgileColumnFieldValue"
+            }
+          ],
+          "ordinal": 2,
+          "presentation": "Fixed",
+          "wipLimit": null,
+          "isResolved": true,
+          "id": "110-10",
+          "$type": "AgileColumn"
+        },
+        {
+          "fieldValues": [
+            {
+              "name": "Verified",
+              "isResolved": true,
+              "id": "111-15",
+              "$type": "AgileColumnFieldValue"
+            }
+          ],
+          "ordinal": 3,
+          "presentation": "Verified",
+          "wipLimit": null,
+          "isResolved": true,
+          "id": "110-11",
+          "$type": "AgileColumn"
+        }
+      ],
+      "id": "108-2",
+      "$type": "ColumnSettings"
+    },
+    "colorCoding": {
+      "prototype": {
+          "name": "Type",
+          "$type": "CustomField"
+      },
+      "id": "108-5",
+      "$type": "FieldBasedColorCoding"
+    },
+    "currentSprint": {
+      "name": "First sprint",
+      "id": "109-2",
+      "$type": "Sprint"
+    },
+    "originalEstimationField": {
+      "name": "OriginalEstimationField",
+      "$type": "CustomField"
+    },
+    "sprintsSettings": {
+      "explicitQuery": null,
+      "isExplicit": true,
+      "disableSprints": false,
+      "hideSubtasksOfCards": false,
+      "cardOnSeveralSprints": false,
+      "defaultSprint": null,
+      "sprintSyncField": null,
+      "id": "108-2",
+      "$type": "SprintsSettings"
+    },
+    "visibleFor": {
+      "allUsersGroup" : false,
+      "icon" : "String",
+      "name" : "String",
+      "ringId" : "String",
+      "teamForProject" : {
+        "shortName": "DP1",
+        "name": "DemoProject1",
+        "id": "0-1",
+        "$type": "Project"
+      },
+      "usersCount" : 2,
+      "id" : "String",
+      "$type" : "UserGroup"
+    },
+    "updateableBy": {
+      "allUsersGroup" : false,
+      "icon" : "String",
+      "name" : "String",
+      "ringId" : "String",
+      "teamForProject" : {
+        "shortName": "DP1",
+        "name": "DemoProject1",
+        "id": "0-1",
+        "$type": "Project"
+      },
+      "usersCount" : 2,
+      "id" : "String",
+      "$type" : "UserGroup"
+    },
+    "status": {
+      "errors": [],
+      "valid": true,
+      "hasJobs": false,
+      "warnings": [],
+      "id": "boardStatus",
+      "$type": "AgileStatus"
+    },
+    "owner": {
+      "fullName": "Demo User 1",
+      "ringId": "0692a47b-3670-452e-8e73-8b166a774705",
+      "id": "1-2",
+      "$type": "User"
+    },
+    "name": "Test Board597fb561-ea1f-4095-9636-859ae4439605",
+    "id": "108-2",
+    "$type": "Agile"
+  }
+]

--- a/tests/YouTrackSharp.Tests/Resources/CompleteAgile.json
+++ b/tests/YouTrackSharp.Tests/Resources/CompleteAgile.json
@@ -1,202 +1,200 @@
-[
-  {
-    "projects": [
-      {
-        "shortName": "DP1",
-        "name": "DemoProject1",
-        "id": "0-1",
-        "$type": "Project"
-      }
-    ],
-    "swimlaneSettings": {
-      "field": {
-        "customField": {
-          "name": "Type",
-          "$type": "CustomField"
-        },
-        "presentation": "Type",
-        "id": "51-2",
+{
+  "projects": [
+    {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    }
+  ],
+  "swimlaneSettings": {
+    "field": {
+      "customField": {
         "name": "Type",
-        "$type": "CustomFilterField"
-      },
-      "values": [
-        {
-          "name": "Feature",
-          "id": "Feature",
-          "$type": "SwimlaneValue"
-        }
-      ],
-      "defaultCardType": {
-        "name": "Task",
-        "id": "Task",
-        "$type": "SwimlaneValue"
-      },
-      "id": "105-3",
-      "$type": "IssueBasedSwimlaneSettings"
-    },
-    "estimationField": {
-      "name": "Estimation",
-      "$type": "CustomField"
-    },
-    "sprints": [
-      {
-        "name": "First sprint",
-        "id": "109-2",
-        "$type": "Sprint"
-      }
-    ],
-    "hideOrphansSwimlane": false,
-    "orphansAtTheTop": false,
-    "visibleForProjectBased": true,
-    "updateableByProjectBased": true,
-    "columnSettings": {
-      "field": {
-        "name": "State",
         "$type": "CustomField"
       },
-      "columns": [
-        {
-          "fieldValues": [
-            {
-              "name": "Open",
-              "isResolved": false,
-              "id": "111-12",
-              "$type": "AgileColumnFieldValue"
-            }
-          ],
-          "ordinal": 0,
-          "presentation": "Open",
-          "wipLimit": null,
-          "isResolved": false,
-          "id": "110-8",
-          "$type": "AgileColumn"
-        },
-        {
-          "fieldValues": [
-            {
-              "name": "In Progress",
-              "isResolved": false,
-              "id": "111-13",
-              "$type": "AgileColumnFieldValue"
-            }
-          ],
-          "ordinal": 1,
-          "presentation": "In Progress",
-          "wipLimit": null,
-          "isResolved": false,
-          "id": "110-9",
-          "$type": "AgileColumn"
-        },
-        {
-          "fieldValues": [
-            {
-              "name": "Fixed",
-              "isResolved": true,
-              "id": "111-14",
-              "$type": "AgileColumnFieldValue"
-            }
-          ],
-          "ordinal": 2,
-          "presentation": "Fixed",
-          "wipLimit": null,
-          "isResolved": true,
-          "id": "110-10",
-          "$type": "AgileColumn"
-        },
-        {
-          "fieldValues": [
-            {
-              "name": "Verified",
-              "isResolved": true,
-              "id": "111-15",
-              "$type": "AgileColumnFieldValue"
-            }
-          ],
-          "ordinal": 3,
-          "presentation": "Verified",
-          "wipLimit": null,
-          "isResolved": true,
-          "id": "110-11",
-          "$type": "AgileColumn"
-        }
-      ],
-      "id": "108-2",
-      "$type": "ColumnSettings"
+      "presentation": "Type",
+      "id": "51-2",
+      "name": "Type",
+      "$type": "CustomFilterField"
     },
-    "colorCoding": {
-      "prototype": {
-          "name": "Type",
-          "$type": "CustomField"
-      },
-      "id": "108-5",
-      "$type": "FieldBasedColorCoding"
+    "values": [
+      {
+        "name": "Feature",
+        "id": "Feature",
+        "$type": "SwimlaneValue"
+      }
+    ],
+    "defaultCardType": {
+      "name": "Task",
+      "id": "Task",
+      "$type": "SwimlaneValue"
     },
-    "currentSprint": {
+    "id": "105-3",
+    "$type": "IssueBasedSwimlaneSettings"
+  },
+  "estimationField": {
+    "name": "Estimation",
+    "$type": "CustomField"
+  },
+  "sprints": [
+    {
       "name": "First sprint",
       "id": "109-2",
       "$type": "Sprint"
-    },
-    "originalEstimationField": {
-      "name": "OriginalEstimationField",
+    }
+  ],
+  "hideOrphansSwimlane": false,
+  "orphansAtTheTop": false,
+  "visibleForProjectBased": true,
+  "updateableByProjectBased": true,
+  "columnSettings": {
+    "field": {
+      "name": "State",
       "$type": "CustomField"
     },
-    "sprintsSettings": {
-      "explicitQuery": null,
-      "isExplicit": true,
-      "disableSprints": false,
-      "hideSubtasksOfCards": false,
-      "cardOnSeveralSprints": false,
-      "defaultSprint": null,
-      "sprintSyncField": null,
-      "id": "108-2",
-      "$type": "SprintsSettings"
-    },
-    "visibleFor": {
-      "allUsersGroup" : false,
-      "icon" : "String",
-      "name" : "String",
-      "ringId" : "String",
-      "teamForProject" : {
-        "shortName": "DP1",
-        "name": "DemoProject1",
-        "id": "0-1",
-        "$type": "Project"
+    "columns": [
+      {
+        "fieldValues": [
+          {
+            "name": "Open",
+            "isResolved": false,
+            "id": "111-12",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 0,
+        "presentation": "Open",
+        "wipLimit": null,
+        "isResolved": false,
+        "id": "110-8",
+        "$type": "AgileColumn"
       },
-      "usersCount" : 2,
-      "id" : "String",
-      "$type" : "UserGroup"
-    },
-    "updateableBy": {
-      "allUsersGroup" : false,
-      "icon" : "String",
-      "name" : "String",
-      "ringId" : "String",
-      "teamForProject" : {
-        "shortName": "DP1",
-        "name": "DemoProject1",
-        "id": "0-1",
-        "$type": "Project"
+      {
+        "fieldValues": [
+          {
+            "name": "In Progress",
+            "isResolved": false,
+            "id": "111-13",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 1,
+        "presentation": "In Progress",
+        "wipLimit": null,
+        "isResolved": false,
+        "id": "110-9",
+        "$type": "AgileColumn"
       },
-      "usersCount" : 2,
-      "id" : "String",
-      "$type" : "UserGroup"
-    },
-    "status": {
-      "errors": [],
-      "valid": true,
-      "hasJobs": false,
-      "warnings": [],
-      "id": "boardStatus",
-      "$type": "AgileStatus"
-    },
-    "owner": {
-      "fullName": "Demo User 1",
-      "ringId": "0692a47b-3670-452e-8e73-8b166a774705",
-      "id": "1-2",
-      "$type": "User"
-    },
-    "name": "Test Board597fb561-ea1f-4095-9636-859ae4439605",
+      {
+        "fieldValues": [
+          {
+            "name": "Fixed",
+            "isResolved": true,
+            "id": "111-14",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 2,
+        "presentation": "Fixed",
+        "wipLimit": null,
+        "isResolved": true,
+        "id": "110-10",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "Verified",
+            "isResolved": true,
+            "id": "111-15",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 3,
+        "presentation": "Verified",
+        "wipLimit": null,
+        "isResolved": true,
+        "id": "110-11",
+        "$type": "AgileColumn"
+      }
+    ],
     "id": "108-2",
-    "$type": "Agile"
-  }
-]
+    "$type": "ColumnSettings"
+  },
+  "colorCoding": {
+    "prototype": {
+        "name": "Type",
+        "$type": "CustomField"
+    },
+    "id": "108-5",
+    "$type": "FieldBasedColorCoding"
+  },
+  "currentSprint": {
+    "name": "First sprint",
+    "id": "109-2",
+    "$type": "Sprint"
+  },
+  "originalEstimationField": {
+    "name": "OriginalEstimationField",
+    "$type": "CustomField"
+  },
+  "sprintsSettings": {
+    "explicitQuery": null,
+    "isExplicit": true,
+    "disableSprints": false,
+    "hideSubtasksOfCards": false,
+    "cardOnSeveralSprints": false,
+    "defaultSprint": null,
+    "sprintSyncField": null,
+    "id": "108-2",
+    "$type": "SprintsSettings"
+  },
+  "visibleFor": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "updateableBy": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "status": {
+    "errors": [],
+    "valid": true,
+    "hasJobs": false,
+    "warnings": [],
+    "id": "boardStatus",
+    "$type": "AgileStatus"
+  },
+  "owner": {
+    "fullName": "Demo User 1",
+    "ringId": "0692a47b-3670-452e-8e73-8b166a774705",
+    "id": "1-2",
+    "$type": "User"
+  },
+  "name": "Test Board597fb561-ea1f-4095-9636-859ae4439605",
+  "id": "108-2",
+  "$type": "Agile"
+}

--- a/tests/YouTrackSharp.Tests/Resources/FullAgile01.json
+++ b/tests/YouTrackSharp.Tests/Resources/FullAgile01.json
@@ -1,0 +1,232 @@
+{
+  "_comment": "Represents a full agile board (no fields are null), with FieldBasedColorCoding, IssueBasedSwimlaneSettings (and CustomFilterField)",
+  "projects": [
+    {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    }
+  ],
+  "swimlaneSettings": {
+    "field": {
+      "customField": {
+        "name": "Type",
+        "$type": "CustomField"
+      },
+      "presentation": "Type",
+      "id": "51-2",
+      "name": "Type",
+      "$type": "CustomFilterField"
+    },
+    "values": [
+      {
+        "name": "Feature",
+        "id": "Feature",
+        "$type": "SwimlaneValue"
+      }
+    ],
+    "defaultCardType": {
+      "name": "Task",
+      "id": "Task",
+      "$type": "SwimlaneValue"
+    },
+    "id": "105-3",
+    "$type": "IssueBasedSwimlaneSettings"
+  },
+  "estimationField": {
+    "name": "Estimation",
+    "$type": "CustomField"
+  },
+  "sprints": [
+    {
+      "name": "First sprint",
+      "id": "109-2",
+      "$type": "Sprint"
+    }
+  ],
+  "hideOrphansSwimlane": false,
+  "orphansAtTheTop": false,
+  "visibleForProjectBased": true,
+  "updateableByProjectBased": true,
+  "columnSettings": {
+    "field": {
+      "name": "State",
+      "$type": "CustomField"
+    },
+    "columns": [
+      {
+        "fieldValues": [
+          {
+            "name": "Open",
+            "isResolved": true,
+            "id": "111-12",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 0,
+        "presentation": "Open",
+        "wipLimit": {
+          "id": "205-0",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-8",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "In Progress",
+            "isResolved": true,
+            "id": "111-13",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 1,
+        "presentation": "In Progress",
+        "wipLimit": {
+          "id": "205-1",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-9",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "Fixed",
+            "isResolved": true,
+            "id": "111-14",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 2,
+        "presentation": "Fixed",
+        "wipLimit": {
+          "id": "205-2",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-10",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "Verified",
+            "isResolved": true,
+            "id": "111-15",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 3,
+        "presentation": "Verified",
+        "wipLimit": {
+          "id": "205-3",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-11",
+        "$type": "AgileColumn"
+      }
+    ],
+    "id": "108-2",
+    "$type": "ColumnSettings"
+  },
+  "colorCoding": {
+    "prototype": {
+        "name": "Type",
+        "$type": "CustomField"
+    },
+    "id": "108-5",
+    "$type": "FieldBasedColorCoding"
+  },
+  "currentSprint": {
+    "name": "First sprint",
+    "id": "109-2",
+    "$type": "Sprint"
+  },
+  "originalEstimationField": {
+    "name": "OriginalEstimationField",
+    "$type": "CustomField"
+  },
+  "sprintsSettings": {
+    "explicitQuery": "project: DemoProject1",
+    "isExplicit": false,
+    "disableSprints": false,
+    "hideSubtasksOfCards": false,
+    "cardOnSeveralSprints": false,
+    "defaultSprint": {
+      "name": "First sprint",
+      "id": "109-2",
+      "$type": "Sprint"
+    },
+    "sprintSyncField": {
+      "name": "State",
+      "$type": "CustomField"
+    },
+    "id": "108-2",
+    "$type": "SprintsSettings"
+  },
+  "visibleFor": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "updateableBy": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "status": {
+    "errors": [],
+    "valid": true,
+    "hasJobs": false,
+    "warnings": [],
+    "id": "boardStatus",
+    "$type": "AgileStatus"
+  },
+  "owner": {
+    "fullName": "Demo User 1",
+    "ringId": "0692a47b-3670-452e-8e73-8b166a774705",
+    "id": "1-2",
+    "$type": "User"
+  },
+  "name": "Full Board 01",
+  "id": "109-1",
+  "$type": "Agile"
+}

--- a/tests/YouTrackSharp.Tests/Resources/FullAgile02.json
+++ b/tests/YouTrackSharp.Tests/Resources/FullAgile02.json
@@ -1,0 +1,251 @@
+{
+  "_comment": "Represents a full agile board (no fields are null), with ProjectBasedColorCoding, AttributeBasedSwimlaneSettings (and PredefinedFilterField)",
+  "projects": [
+    {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    }
+  ],
+  "swimlaneSettings": {
+    "field": {
+      "presentation": "Type",
+      "id": "51-3",
+      "name": "Type",
+      "$type": "PredefinedFilterField"
+    },
+    "values": [
+      {
+        "name": "Feature 01",
+        "isResolved": true,
+        "id": "61-3",
+        "$type": "SwimlaneEntityAttributeValue"
+      },
+      {
+        "name": "Feature 02",
+        "isResolved": true,
+        "id": "61-4",
+        "$type": "SwimlaneEntityAttributeValue"
+      },
+      {
+        "name": "Feature 03",
+        "isResolved": false,
+        "id": "61-5",
+        "$type": "SwimlaneEntityAttributeValue"
+      }
+    ],
+    "id": "105-3",
+    "name": "Swimlane Settings 01",
+    "$type": "AttributeBasedSwimlaneSettings"
+  },
+  "estimationField": {
+    "name": "Estimation",
+    "$type": "CustomField"
+  },
+  "sprints": [
+    {
+      "name": "First sprint",
+      "id": "109-2",
+      "$type": "Sprint"
+    }
+  ],
+  "hideOrphansSwimlane": true,
+  "orphansAtTheTop": true,
+  "visibleForProjectBased": true,
+  "updateableByProjectBased": true,
+  "columnSettings": {
+    "field": {
+      "name": "State",
+      "$type": "CustomField"
+    },
+    "columns": [
+      {
+        "fieldValues": [
+          {
+            "name": "Open",
+            "isResolved": true,
+            "id": "111-12",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 0,
+        "presentation": "Open",
+        "wipLimit": {
+          "id": "205-0",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-8",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "In Progress",
+            "isResolved": true,
+            "id": "111-13",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 1,
+        "presentation": "In Progress",
+        "wipLimit": {
+          "id": "205-1",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-9",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "Fixed",
+            "isResolved": true,
+            "id": "111-14",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 2,
+        "presentation": "Fixed",
+        "wipLimit": {
+          "id": "205-2",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-10",
+        "$type": "AgileColumn"
+      },
+      {
+        "fieldValues": [
+          {
+            "name": "Verified",
+            "isResolved": true,
+            "id": "111-15",
+            "$type": "AgileColumnFieldValue"
+          }
+        ],
+        "ordinal": 3,
+        "presentation": "Verified",
+        "wipLimit": {
+          "id": "205-3",
+          "max": "10",
+          "min": "3",
+          "column": "3",
+          "$type": "WIPLimit"
+        },
+        "isResolved": true,
+        "id": "110-11",
+        "$type": "AgileColumn"
+      }
+    ],
+    "id": "108-2",
+    "$type": "ColumnSettings"
+  },
+  "colorCoding": {
+    "id": "108-5",
+    "projectColors": [
+      {
+        "id": "120-1",
+        "project": {
+          "shortName": "DP1",
+          "name": "DemoProject1",
+          "id": "0-1",
+          "$type": "Project"
+        },
+        "color": {
+          "id": "130-1",
+          "background": "White",
+          "foreground": "Black",
+          "$type": "FieldStyle"
+        },
+        "$type": "ProjectColor"
+      }
+    ],
+    "$type": "ProjectBasedColorCoding"
+  },
+  "currentSprint": {
+    "name": "First sprint",
+    "id": "109-2",
+    "$type": "Sprint"
+  },
+  "originalEstimationField": {
+    "name": "OriginalEstimationField",
+    "$type": "CustomField"
+  },
+  "sprintsSettings": {
+    "explicitQuery": "project: DemoProject1",
+    "isExplicit": false,
+    "disableSprints": false,
+    "hideSubtasksOfCards": false,
+    "cardOnSeveralSprints": false,
+    "defaultSprint": {
+      "name": "First sprint",
+      "id": "109-2",
+      "$type": "Sprint"
+    },
+    "sprintSyncField": {
+      "name": "State",
+      "$type": "CustomField"
+    },
+    "id": "108-2",
+    "$type": "SprintsSettings"
+  },
+  "visibleFor": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "updateableBy": {
+    "allUsersGroup" : false,
+    "icon" : "String",
+    "name" : "String",
+    "ringId" : "String",
+    "teamForProject" : {
+      "shortName": "DP1",
+      "name": "DemoProject1",
+      "id": "0-1",
+      "$type": "Project"
+    },
+    "usersCount" : 2,
+    "id" : "String",
+    "$type" : "UserGroup"
+  },
+  "status": {
+    "errors": [],
+    "valid": true,
+    "hasJobs": false,
+    "warnings": [],
+    "id": "boardStatus",
+    "$type": "AgileStatus"
+  },
+  "owner": {
+    "fullName": "Demo User 1",
+    "ringId": "0692a47b-3670-452e-8e73-8b166a774705",
+    "id": "1-2",
+    "$type": "User"
+  },
+  "name": "Full Board 02",
+  "id": "109-2",
+  "$type": "Agile"
+}

--- a/tests/YouTrackSharp.Tests/YouTrackSharp.Tests.csproj
+++ b/tests/YouTrackSharp.Tests/YouTrackSharp.Tests.csproj
@@ -19,7 +19,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Resources\agile.json" />
-    <EmbeddedResource Include="Resources\CompleteAgile.json" />
+    <EmbeddedResource Include="Resources\FullAgile02.json" />
+    <EmbeddedResource Include="Resources\FullAgile01.json" />
   </ItemGroup>
 </Project>

--- a/tests/YouTrackSharp.Tests/YouTrackSharp.Tests.csproj
+++ b/tests/YouTrackSharp.Tests/YouTrackSharp.Tests.csproj
@@ -18,4 +18,8 @@
       <Name>YouTrackSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\agile.json" />
+    <EmbeddedResource Include="Resources\CompleteAgile.json" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
If you still accept pull requests, I would like to submit some work on issue #81 (update to new agile board API).

This includes an updated model for the new Agile board API, and a service to retrieve Agile boards, with an option for verbosity of the retrieved data (using the API described at https://www.jetbrains.com/help/youtrack/standalone/resource-api-agiles.html#get_all-Agile-method). For now it's limited to that, but the infrastructure is in place to add more.

I added some attributes (namely `KnownTypeAttribute `and `VerboseAttribute`) to help with:
-  the deserialization of the JSON objects for polymorphic fields (see `KnownTypeConverter` & `KnownTypeListConverter`),
-  and the generation of the `field` parameter in the REST calls (see `FieldSyntaxEncoder`).

Please let me know if that approach is acceptable.


If possible, I would like to add more to that shortly (get agile board by ID, filters, and also some additional services to work with sprints).

Thanks for your time and consideration