### PR TITLE
history change can also return VCS changes

### DIFF
--- a/src/YouTrackSharp/Issues/Change.cs
+++ b/src/YouTrackSharp/Issues/Change.cs
@@ -81,6 +81,11 @@ namespace YouTrackSharp.Issues
                     fieldChange.From.Value = a.Removed == null ? new JArray() : JArray.FromObject(a.Removed);
                     fieldChange.To.Value = a.Added == null ? new JArray() : JArray.FromObject(a.Added);
                     break;
+                case VcsChangeActivityItem a:
+                    fieldChange.Name = "vcs";
+                    fieldChange.From.Value = a.Removed == null ? new JArray() : JArray.FromObject(a.Removed);
+                    fieldChange.To.Value = a.Added == null ? new JArray() : JArray.FromObject(a.Added);
+                    break;
                 case ProjectActivityItem a:
                     fieldChange.Name = "project";
                     fieldChange.From.Value = new JArray() {JObject.FromObject(a.Removed)};

--- a/src/YouTrackSharp/Issues/IIssuesService.cs
+++ b/src/YouTrackSharp/Issues/IIssuesService.cs
@@ -130,11 +130,12 @@ namespace YouTrackSharp.Issues
         /// </summary>
         /// <remarks>Uses the REST API <a href="https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-activities.html#get_all-ActivityItem-method">Get Changes of an Issue</a>.</remarks>
         /// <param name="issueId">Id of the issue to get change history for.</param>
+        /// <param name="categories">Comma separated category types e.g. IssueResolvedCategory.</param>
         /// <returns>An <see cref="T:System.Collections.Generic.IEnumerable`1" /> of <see cref="Change" /> for the requested issue <paramref name="issueId"/>.</returns>
         /// <exception cref="T:System.ArgumentNullException">When the <paramref name="issueId"/> is null or empty.</exception>
         /// <exception cref="T:System.Net.HttpRequestException">When the call to the remote YouTrack server instance failed.</exception>
-        Task<IEnumerable<Change>> GetChangeHistoryForIssue(string issueId);
-
+        Task<IEnumerable<Change>> GetChangeHistoryForIssue(string issueId, string categories = "AttachmentsCategory,CustomFieldCategory,DescriptionCategory,IssueResolvedCategory,LinksCategory,ProjectCategory,IssueVisibilityCategory,SprintCategory,SummaryCategory,TagsCategory,VcsChangeCategory");
+        
         /// <summary>
         /// Get comments for a specific issue from the server.
         /// </summary>

--- a/src/YouTrackSharp/Issues/IssuesService.History.cs
+++ b/src/YouTrackSharp/Issues/IssuesService.History.cs
@@ -7,11 +7,11 @@ namespace YouTrackSharp.Issues
 {
     public partial class IssuesService
     {
-        private static string ACTIVITIES_CATEGORIES =
-            "AttachmentsCategory,CustomFieldCategory,DescriptionCategory,IssueResolvedCategory,LinksCategory,ProjectCategory,IssueVisibilityCategory,SprintCategory,SummaryCategory,TagsCategory";
+        private const string ACTIVITIES_CATEGORIES =
+            "AttachmentsCategory,CustomFieldCategory,DescriptionCategory,IssueResolvedCategory,LinksCategory,ProjectCategory,IssueVisibilityCategory,SprintCategory,SummaryCategory,TagsCategory,VcsChangeCategory";
         
         /// <inheritdoc />
-        public async Task<IEnumerable<Change>> GetChangeHistoryForIssue(string issueId)
+        public async Task<IEnumerable<Change>> GetChangeHistoryForIssue(string issueId, string categories = ACTIVITIES_CATEGORIES)
         {
             if (string.IsNullOrEmpty(issueId))
             {
@@ -20,7 +20,7 @@ namespace YouTrackSharp.Issues
 
             var client = await _connection.GetAuthenticatedApiClient();
             var response = await client.IssuesActivitiesGetAsync(issueId,
-                ACTIVITIES_CATEGORIES, false, null, null, null, Constants.FieldsQueryStrings.Activities);
+                categories, false, null, null, null, Constants.FieldsQueryStrings.Activities);
             
             return response.Select(Change.FromApiEntity).ToList();
         }


### PR DESCRIPTION
I needed to get VCS changes, for some reason the function GetChangeHistoryForIssue did not return this kind of ActivityItem.
You can also specify the parameter categories to function GetChangeHistoryForIssue, that returns just specific type of ActivityItem.
This might come in handy because you do not need to iterate thru items you do not need.